### PR TITLE
送信時のActivityPub公開範囲

### DIFF
--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -50,9 +50,21 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		? note.mentionedRemoteUsers.map(x => x.uri)
 		: [];
 
-	const cc = ['public', 'home', 'followers'].includes(note.visibility)
-		? [`${attributedTo}/followers`].concat(mentions)
-		: [];
+	let to: string[] = [];
+	let cc: string[] = [];
+
+	if (note.visibility == 'public') {
+		to = ['https://www.w3.org/ns/activitystreams#Public'];
+		cc = [`${attributedTo}/followers`].concat(mentions);
+	} else if (note.visibility == 'home') {
+		to = [`${attributedTo}/followers`];
+		cc = ['https://www.w3.org/ns/activitystreams#Public'].concat(mentions);
+	} else if (note.visibility == 'followers') {
+		to = [`${attributedTo}/followers`];
+		cc = mentions;
+	} else {
+		to = mentions;
+	}
 
 	const mentionedUsers = note.mentions ? await User.find({
 		_id: {
@@ -74,7 +86,7 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		summary: note.cw,
 		content: toHtml(note),
 		published: note.createdAt.toISOString(),
-		to: 'https://www.w3.org/ns/activitystreams#Public',
+		to,
 		cc,
 		inReplyTo,
 		attachment: (await promisedFiles).map(renderDocument),

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -19,6 +19,8 @@ export default async (user: ILocalUser) => {
 		id,
 		inbox: `${id}/inbox`,
 		outbox: `${id}/outbox`,
+		followers: `${id}/followers`,
+		following: `${id}/following`,
 		sharedInbox: `${config.url}/inbox`,
 		url: `${config.url}/@${user.username}`,
 		preferredUsername: user.username,

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -89,6 +89,48 @@ router.get('/users/:user/outbox', async ctx => {
 	ctx.body = pack(rendered);
 });
 
+// followers
+router.get('/users/:user/followers', async ctx => {
+	const userId = new mongo.ObjectID(ctx.params.user);
+
+	const user = await User.findOne({
+		_id: userId,
+		host: null
+	});
+
+	if (user === null) {
+		ctx.status = 404;
+		return;
+	}
+
+	// TODO: Implement fetch and render
+
+	const rendered = renderOrderedCollection(`${config.url}/users/${userId}/followers`, 0, []);
+
+	ctx.body = pack(rendered);
+});
+
+// following
+router.get('/users/:user/following', async ctx => {
+	const userId = new mongo.ObjectID(ctx.params.user);
+
+	const user = await User.findOne({
+		_id: userId,
+		host: null
+	});
+
+	if (user === null) {
+		ctx.status = 404;
+		return;
+	}
+
+	// TODO: Implement fetch and render
+
+	const rendered = renderOrderedCollection(`${config.url}/users/${userId}/following`, 0, []);
+
+	ctx.body = pack(rendered);
+});
+
 // publickey
 router.get('/users/:user/publickey', async ctx => {
 	const userId = new mongo.ObjectID(ctx.params.user);


### PR DESCRIPTION
今まで、ActivityPub 送信時に全て公開扱いになっていたのを、Mastodonライクにする。

src/remote/activitypub/renderer/person.ts
AP Person object に、Followers/Following collection が定義されてないとフォロー系が効かないため追加

src/server/activitypub.ts
AP Followers/Following collection は、ちゃんと実装しておらず常に0件を返す。
Mastodonでも、繋がりを隠すオプションを有効にするとここが0件になるのでとりあえず大丈夫かなと。

src/remote/activitypub/renderer/note.ts
toとccをMastodonライクなVisibilityで送信するようにしている

問題
今までの Person object で Followers/Following collection を通知してなかったのですが
その古いPerson objectを持ってるMastodonインスタンスに対して送ると
to, cc の followers 指定の部分が無視されてそう。
そのため、フォロワー限定投稿はしばらく（？）Mastodonにとどかなくなりそう。