### PR TITLE
Fix リモートにNSFWが効かない

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -78,12 +78,16 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	}
 	//#endergion
 
+	// Noteがsensitiveなら添付もsensitiveにする for Mastodon
+	// ただし既にいずれかの添付がsensitiveならしない for Misskey
+	if (note.sensitive && note.attachment.filter(attach => attach.sensitive).length > 0) {
+		note.attachment = note.attachment.map(attach => attach.sensitive = note.sensitive);
+	}
+
 	// 添付メディア
 	// TODO: attachmentは必ずしもImageではない
 	// TODO: attachmentは必ずしも配列ではない
-	// Noteがsensitiveなら添付もsensitiveにする
 	const media = note.attachment
-		.map(attach => attach.sensitive = note.sensitive)
 		? await Promise.all(note.attachment.map(x => resolveImage(actor, x)))
 		: [];
 

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -81,7 +81,9 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	// 添付メディア
 	// TODO: attachmentは必ずしもImageではない
 	// TODO: attachmentは必ずしも配列ではない
+	// Noteがsensitiveなら添付もsensitiveにする
 	const media = note.attachment
+		.map(attach => attach.sensitive = note.sensitive)
 		? await Promise.all(note.attachment.map(x => resolveImage(actor, x)))
 		: [];
 

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -78,16 +78,12 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	}
 	//#endergion
 
-	// Noteがsensitiveなら添付もsensitiveにする for Mastodon
-	// ただし既にいずれかの添付がsensitiveならしない for Misskey
-	if (note.sensitive && note.attachment.filter(attach => attach.sensitive).length > 0) {
-		note.attachment = note.attachment.map(attach => attach.sensitive = note.sensitive);
-	}
-
 	// 添付メディア
 	// TODO: attachmentは必ずしもImageではない
 	// TODO: attachmentは必ずしも配列ではない
+	// Noteがsensitiveなら添付もsensitiveにする
 	const media = note.attachment
+		.map(attach => attach.sensitive = note.sensitive)
 		? await Promise.all(note.attachment.map(x => resolveImage(actor, x)))
 		: [];
 

--- a/src/remote/activitypub/renderer/document.ts
+++ b/src/remote/activitypub/renderer/document.ts
@@ -4,6 +4,5 @@ import { IDriveFile } from '../../../models/drive-file';
 export default (file: IDriveFile) => ({
 	type: 'Document',
 	mediaType: file.contentType,
-	url: file.metadata.url || `${config.drive_url}/${file._id}`,
-	sensitive: file.metadata.isSensitive
+	url: file.metadata.url || `${config.drive_url}/${file._id}`
 });

--- a/src/remote/activitypub/renderer/document.ts
+++ b/src/remote/activitypub/renderer/document.ts
@@ -4,5 +4,6 @@ import { IDriveFile } from '../../../models/drive-file';
 export default (file: IDriveFile) => ({
 	type: 'Document',
 	mediaType: file.contentType,
-	url: file.metadata.url || `${config.drive_url}/${file._id}`
+	url: file.metadata.url || `${config.drive_url}/${file._id}`,
+	sensitive: file.metadata.isSensitive
 });

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -79,6 +79,8 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		...mentionTags,
 	];
 
+	const files = await promisedFiles;
+
 	return {
 		id: `${config.url}/notes/${note._id}`,
 		type: 'Note',
@@ -89,7 +91,8 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		to,
 		cc,
 		inReplyTo,
-		attachment: (await promisedFiles).map(renderDocument),
+		attachment: files.map(renderDocument),
+		sensitive: files.some(file => file.metadata.isSensitive),
 		tag
 	};
 }

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -16,6 +16,7 @@ export interface IObject {
 	image?: any;
 	url?: string;
 	tag?: any[];
+	sensitive?: boolean;
 }
 
 export interface IActivity extends IObject {


### PR DESCRIPTION
https://github.com/syuilo/misskey/issues/2238
https://github.com/syuilo/misskey/issues/2326

Misskey => Misskey で伝わらない:
Imageにはsensitive付けてるがDocumentには付けてないため
→Documentにも付けるように変更

Misskey <=> Mastodon で伝わらない: 
  Misskey: sensitiveはAttachmentにつける のに対して、
  Mastodon: sensitiveはNoteに付ける ため。
→AP送信時に、どれか1つの添付ファイルがsensitiveなら Noteにsensitiveを付けるように。
→AP受信時に、Noteがsensitiveなら 全部の添付ファイルにsensitiveを付けるように。

NSFW, NonNSFW混在時に
Mastodonへ混在が伝わらないのはしょうがないとして
Misskeyへも伝わらない