### PR TITLE
Pleromaとつながらないのを修正

### DIFF
--- a/src/remote/activitypub/renderer/announce.ts
+++ b/src/remote/activitypub/renderer/announce.ts
@@ -6,6 +6,7 @@ export default (object: any, note: INote) => {
 
 	return {
 		id: `${config.url}/notes/${note._id}`,
+		actor: `${config.url}/users/${note.userId}`,
 		type: 'Announce',
 		published: note.createdAt.toISOString(),
 		to: ['https://www.w3.org/ns/activitystreams#Public'],

--- a/src/remote/activitypub/renderer/create.ts
+++ b/src/remote/activitypub/renderer/create.ts
@@ -1,4 +1,12 @@
-export default (object: any) => ({
-	type: 'Create',
-	object
-});
+import config from '../../../config';
+import { INote } from '../../../models/note';
+
+export default (object: any, note: INote) => {
+	return {
+		id: `${config.url}/notes/${note._id}/activity`,
+		actor: `${config.url}/users/${note.userId}`,
+		type: 'Create',
+		published: note.createdAt.toISOString(),
+		object
+	};
+};

--- a/src/remote/activitypub/renderer/create.ts
+++ b/src/remote/activitypub/renderer/create.ts
@@ -2,11 +2,16 @@ import config from '../../../config';
 import { INote } from '../../../models/note';
 
 export default (object: any, note: INote) => {
-	return {
+	const activity = {
 		id: `${config.url}/notes/${note._id}/activity`,
 		actor: `${config.url}/users/${note.userId}`,
 		type: 'Create',
 		published: note.createdAt.toISOString(),
 		object
-	};
+	} as any;
+
+	if (object.to) activity.to = object.to;
+	if (object.cc) activity.cc = object.cc;
+
+	return activity;
 };

--- a/src/remote/activitypub/renderer/delete.ts
+++ b/src/remote/activitypub/renderer/delete.ts
@@ -1,4 +1,8 @@
-export default (object: any) => ({
+import config from '../../../config';
+import { ILocalUser } from "../../../models/user";
+
+export default (object: any, user: ILocalUser) => ({
 	type: 'Delete',
+	actor: `${config.url}/users/${user._id}`,
 	object
 });

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -1,7 +1,16 @@
-export default (x: any) => Object.assign({
-	'@context': [
-		'https://www.w3.org/ns/activitystreams',
-		'https://w3id.org/security/v1',
-		{ Hashtag: 'as:Hashtag' }
-	]
-}, x);
+import config from '../../../config';
+import * as uuid from 'uuid';
+
+export default (x: any) => {
+	if (x !== null && typeof x === 'object' && x.id == null) {
+		x.id = `${config.url}/${uuid.v4()}`;
+	}
+
+	return Object.assign({
+		'@context': [
+			'https://www.w3.org/ns/activitystreams',
+			'https://w3id.org/security/v1',
+			{ Hashtag: 'as:Hashtag' }
+		]
+	}, x);
+};

--- a/src/remote/activitypub/renderer/undo.ts
+++ b/src/remote/activitypub/renderer/undo.ts
@@ -1,4 +1,8 @@
-export default (object: any) => ({
+import config from '../../../config';
+import { ILocalUser, IUser } from "../../../models/user";
+
+export default (object: any, user: ILocalUser | IUser) => ({
 	type: 'Undo',
+	actor: `${config.url}/users/${user._id}`,
 	object
 });

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -19,6 +19,9 @@ export default (user: ILocalUser, url: string, object: any) => new Promise((reso
 		port,
 		method: 'POST',
 		path: pathname + search,
+		headers: {
+			'Content-Type': 'application/activity+json'
+		}
 	}, res => {
 		log(`${url} --> ${res.statusCode}`);
 

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -35,7 +35,7 @@ export default (user: ILocalUser, url: string, object: any) => new Promise((reso
 	sign(req, {
 		authorizationHeaderName: 'Signature',
 		key: user.keypair,
-		keyId: `acct:${user.username}@${config.host}`
+		keyId: `${config.url}/users/${user._id}/publickey`
 	});
 
 	// Signature: Signature ... => Signature: ...

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -25,7 +25,7 @@ function inbox(ctx: Router.IRouterContext) {
 	ctx.req.headers.authorization = 'Signature ' + ctx.req.headers.signature;
 
 	try {
-		signature = httpSignature.parseRequest(ctx.req);
+		signature = httpSignature.parseRequest(ctx.req, { 'headers': [] });
 	} catch (e) {
 		ctx.status = 401;
 		return;

--- a/src/services/following/delete.ts
+++ b/src/services/following/delete.ts
@@ -56,7 +56,7 @@ export default async function(follower: IUser, followee: IUser) {
 	}
 
 	if (isLocalUser(follower) && isRemoteUser(followee)) {
-		const content = pack(renderUndo(renderFollow(follower, followee)));
+		const content = pack(renderUndo(renderFollow(follower, followee), follower));
 		deliver(follower, content, followee.inbox);
 	}
 }

--- a/src/services/following/requests/cancel.ts
+++ b/src/services/following/requests/cancel.ts
@@ -8,7 +8,7 @@ import { publishUserStream } from '../../../stream';
 
 export default async function(followee: IUser, follower: IUser) {
 	if (isRemoteUser(followee)) {
-		const content = pack(renderUndo(renderFollow(follower, followee)));
+		const content = pack(renderUndo(renderFollow(follower, followee), follower));
 		deliver(follower as ILocalUser, content, followee.inbox);
 	}
 

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -240,7 +240,7 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 async function renderActivity(data: Option, note: INote) {
 	const content = data.renote && data.text == null
 		? renderAnnounce(data.renote.uri ? data.renote.uri : `${config.url}/notes/${data.renote._id}`, note)
-		: renderCreate(await renderNote(note, false));
+		: renderCreate(await renderNote(note, false), note);
 
 	return packAp(content);
 }

--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -32,7 +32,7 @@ export default async function(user: IUser, note: INote) {
 
 	//#region ローカルの投稿なら削除アクティビティを配送
 	if (isLocalUser(user)) {
-		const content = pack(renderDelete(await renderNote(note)));
+		const content = pack(renderDelete(await renderNote(note), user));
 
 		const followings = await Following.find({
 			followeeId: user._id,


### PR DESCRIPTION
Pleromaとつながらないのを修正した

- Content-Typeを送ってなかったので、送るようにした。
- keyIdが古い形式だったので、新しい形式で送るようにした。
- Activity id を送ってなかったので、送るようにした。
- HTTP Signatureを検証する際にDateヘッダが含まれてないとエラーになるので、除外した。
- Create Note の activity の階層にもtoが必要そうなので、追加した。
- Create Note, Announce, Undo Follow, Delete でも actor を送るようにした。

```
  id: Activity ID   ←追加
  actor: ユーザー   ←追加
  type: 'Create'
  to: TO   ←追加(下にあるのと同じ)
  cc: CC   ←追加(下にあるのと同じ)
  object:
    id: Note ID
    attributedTo: ユーザー
    type: 'Note'
    to: TO
    cc: CC
```
