### PR TITLE
8.12.0 から 8.12.0 で受け側で未認知ユーザーが追加できないのを修正

### DIFF
--- a/src/queue/processors/http/process-inbox.ts
+++ b/src/queue/processors/http/process-inbox.ts
@@ -46,7 +46,7 @@ export default async (job: bq.Job, done: any): Promise<void> => {
 
 		// アクティビティを送信してきたユーザーがまだMisskeyサーバーに登録されていなかったら登録する
 		if (user === null) {
-			user = await resolvePerson(signature.keyId) as IRemoteUser;
+			user = await resolvePerson(activity.actor) as IRemoteUser;
 		}
 	}
 


### PR DESCRIPTION
https://github.com/syuilo/misskey/issues/2480#issuecomment-415967961
- A(新)→B(旧) に 送ったときに、Bで未認知だと登録できない
- A(新)→B(新) に 送ったときに、Bで未認知だと登録できない
で2番めのB(新)のサーバーになるパターンのみ解決する