### PR TITLE
Implement ActivityPub Update<Person>

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -291,7 +291,9 @@ export async function updatePerson(uri: string, resolver?: Resolver): Promise<vo
 			name: person.name,
 			url: person.url,
 			endpoints: person.endpoints,
-			isCat: (person as any).isCat === true ? true : false
+			isBot: object.type == 'Service',
+			isCat: (person as any).isCat === true ? true : false,
+			isLocked: person.manuallyApprovesFollowers
 		}
 	});
 }

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -139,6 +139,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 			avatarId: null,
 			bannerId: null,
 			createdAt: Date.parse(person.published) || null,
+			updatedAt: new Date(),
 			description: htmlToMFM(person.summary),
 			followersCount,
 			followingCount,

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -293,7 +293,12 @@ export async function updatePerson(uri: string, resolver?: Resolver): Promise<vo
 			endpoints: person.endpoints,
 			isBot: object.type == 'Service',
 			isCat: (person as any).isCat === true ? true : false,
-			isLocked: person.manuallyApprovesFollowers
+			isLocked: person.manuallyApprovesFollowers,
+			createdAt: Date.parse(person.published) || null,
+			publicKey: {
+				id: person.publicKey.id,
+				publicKeyPem: person.publicKey.publicKeyPem
+			},
 		}
 	});
 }

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -216,10 +216,12 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 
 /**
  * Personの情報を更新します。
- *
  * Misskeyに対象のPersonが登録されていなければ無視します。
+ * @param uri URI of Person
+ * @param resolver Resolver
+ * @param hint Hint of Person object (この値が正当なPersonの場合、Remote resolveをせずに更新に利用します)
  */
-export async function updatePerson(uri: string, resolver?: Resolver): Promise<void> {
+export async function updatePerson(uri: string, resolver?: Resolver, hint?: object): Promise<void> {
 	if (typeof uri !== 'string') throw 'uri is not string';
 
 	// URIがこのサーバーを指しているならスキップ
@@ -237,7 +239,7 @@ export async function updatePerson(uri: string, resolver?: Resolver): Promise<vo
 
 	if (resolver == null) resolver = new Resolver();
 
-	const object = await resolver.resolve(uri) as any;
+	const object = hint || await resolver.resolve(uri) as any;
 
 	const err = validatePerson(object, uri);
 

--- a/src/remote/activitypub/renderer/update.ts
+++ b/src/remote/activitypub/renderer/update.ts
@@ -1,0 +1,14 @@
+import config from '../../../config';
+import { ILocalUser } from '../../../models/user';
+
+export default (object: any, user: ILocalUser) => {
+	const activity = {
+		id: `${config.url}/users/${user._id}#updates/${new Date().getTime()}`,
+		actor: `${config.url}/users/${user._id}`,
+		type: 'Update',
+		to: [ 'https://www.w3.org/ns/activitystreams#Public' ],
+		object
+	} as any;
+
+	return activity;
+};

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -5,6 +5,7 @@ import DriveFile from '../../../../models/drive-file';
 import acceptAllFollowRequests from '../../../../services/following/requests/accept-all';
 import { IApp } from '../../../../models/app';
 import config from '../../../../config';
+import { publishToFollowers } from '../../../../services/i/update';
 
 export const meta = {
 	desc: {
@@ -144,4 +145,7 @@ export default async (params: any, user: ILocalUser, app: IApp) => new Promise(a
 	if (user.isLocked && isLocked === false) {
 		acceptAllFollowRequests(user);
 	}
+
+	// フォロワーにUpdateを配信
+	publishToFollowers(user._id);
 });

--- a/src/services/i/update.ts
+++ b/src/services/i/update.ts
@@ -1,0 +1,38 @@
+import * as mongo from 'mongodb';
+import User, { isLocalUser, isRemoteUser } from '../../models/user';
+import Following from '../../models/following';
+import renderPerson from '../../remote/activitypub/renderer/person';
+import renderUpdate from '../../remote/activitypub/renderer/update';
+import packAp from '../../remote/activitypub/renderer';
+import { deliver } from '../../queue';
+
+export async function publishToFollowers(userId: mongo.ObjectID) {
+	const user = await User.findOne({
+		_id: userId
+	});
+
+	const followers = await Following.find({
+		followeeId: user._id
+	});
+
+	const queue: string[] = [];
+
+	// フォロワーがリモートユーザーかつ投稿者がローカルユーザーならUpdateを配信
+	if (isLocalUser(user)) {
+		followers.map(following => {
+			const follower = following._follower;
+
+			if (isRemoteUser(follower)) {
+				const inbox = follower.sharedInbox || follower.inbox;
+				if (!queue.includes(inbox)) queue.push(inbox);
+			}
+		});
+
+		if (queue.length > 0) {
+			const content = packAp(renderUpdate(await renderPerson(user), user));
+			queue.forEach(inbox => {
+				deliver(user, content, inbox);
+			});
+		}
+	}
+}


### PR DESCRIPTION
ActivityPub Update<Person> activity の実装
Resolve #1448, #1499, #2420

実装する間に直しておいたほうがいいため、少し別件の修正
795fc5e 新規認知ユーザーが1日待たずにアップデート発動してしまうのを修正
eee9835 updatePersonに isBot, isLocked が漏れてるので修正
15eaebe updatePersonで リモートインスタンスのDBが飛んでユーザーが変わった場合などを考慮して createdAt, publicKey を更新するように

3efffbc Update activity 受信分の実装
57a63d3 Update activity 送信分の実装