### PR TITLE
APオブジェクト採番API

### DIFF
--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -1,0 +1,113 @@
+import $ from 'cafy';
+import getParams from '../../get-params';
+import config from '../../../../config';
+import * as mongo from 'mongodb';
+import User, { pack as packUser, IUser } from '../../../../models/user';
+import { createPerson } from '../../../../remote/activitypub/models/person';
+import Note, { pack as packNote, INote } from '../../../../models/note';
+import { createNote } from '../../../../remote/activitypub/models/note';
+import Resolver from '../../../../remote/activitypub/resolver';
+
+export const meta = {
+	desc: {
+		'ja-JP': 'ActivityPubオブジェクトを参照します。'
+	},
+
+	requireCredential: false,
+
+	params: {
+		uri: $.str.note({
+			desc: {
+				'ja-JP': 'URI'
+			}
+		}),
+	},
+};
+
+export default (params: any) => new Promise(async (res, rej) => {
+	const [ps, psErr] = getParams(meta, params);
+	if (psErr) return rej(psErr);
+
+	const object = await fetchAny(ps.uri, true);
+	if (object !== null) res(object);
+
+	return rej('object not found');
+});
+
+async function fetchAny(uri: string, searchUrl: boolean = true) {
+	// URIがこのサーバーを指しているなら、ローカルユーザーIDとしてDBからフェッチ
+	if (uri.startsWith(config.url + '/')) {
+		const id = new mongo.ObjectID(uri.split('/').pop());
+		const [ user, note ] = await Promise.all([
+			User.findOne({ _id: id }),
+			Note.findOne({ _id: id })
+		]);
+
+		const packed = await mergePack(user, note);
+		if (packed !== null) return packed;
+	}
+
+	// uri(AP Object id)としてDB検索
+	{
+		const [ user, note ] = await Promise.all([
+			User.findOne({ uri: uri }),
+			Note.findOne({ uri: uri })
+		]);
+
+		const packed = await mergePack(user, note);
+		if (packed !== null) return packed;
+	}
+
+	// オプションによりurlからもDB検索
+	if (searchUrl) {
+		const [ user, note ] = await Promise.all([
+			User.findOne({ url: uri }),
+			null // TODO: Note.url は蓄積してないためここで取得不可
+		]);
+
+		const packed = await mergePack(user, note);
+		if (packed !== null) return packed;
+	}
+
+	// リモートからフェッチ
+	// /@user のような正規id以外で取得できるURLのために、一度fetchしてidに正規化する
+	const resolver = new Resolver();
+	const object = await resolver.resolve(uri) as any;
+
+	if (object.type === 'Person') {
+		const user = await createPerson(object.id);
+		return {
+			type: 'User',
+			object: user
+		};
+	}
+
+	if (object.type === 'Note') {
+		// TODO: URIが正規idでなかった && DB上では正規idが既存だった 場合にduplicate keyでエラーになる
+		const note = await createNote(object.id);
+		return {
+			type: 'Note',
+			object: note
+		};
+	}
+
+	return null;
+}
+
+async function mergePack(user: IUser, note: INote) {
+	if (user !== null) {
+		return {
+			type: 'User',
+			object: await packUser(user, null, { detail: true })
+		};
+	}
+
+	if (note !== null) {
+		return {
+			type: 'Note',
+			object: await packNote(note, null, { detail: true })
+		};
+	}
+
+	return null;
+}


### PR DESCRIPTION
https://github.com/syuilo/misskey/issues/2274

作りかけ

## 概要
ActivityPub Object(Person or Note)のURIを指定すると
必要によりリモート解決とDB登録を行い、オブジェクトを返すAPI。

## 仕様
`uri=ActivityPub Object(Person or Note)のURI` で呼び出し

対象がPersonだった場合`{ type: "User", object: UserEntity }`を返す
対象がNoteだった場合`{ type: "Note", object: NoteEntity }`を返す

## 制限
uriの指定としては、正式なActivityPub Object id以外は一部使用できない

**以下のような、正式なActivityPub Object id指定は対応**
https://example.com/users/xxxxx (Misskey/Mastodon)
https://example.com/notes/xxxxx (Misskey)
https://example.com/users/xxxxx/statuses/yyyyy (Mastodon)

**エイリアス的なURL(ActivityPub Object id とは違うURLだが、ActivityPub Objectを返すURL)のうちPersonについては対応**
https://example.com/@xxxxx (Misskey/Mastodon)

**エイリアス的なURLのうちNoteについては未対応**
DBに蓄積する仕組みではないため容易に対応できない
未認知は正常に返る/認知済みは返らないという動作をする

具体的にはMastodonの以下のURLが該当
https://example.com/@xxxxx/yyyyy (Mastodon)

クライアント側で以下のように置換したりして送る必要がありそう
https://example.com/users/xxxxx/statuses/yyyyy