### PR TITLE
Implement Talk has read federation

### DIFF
--- a/src/models/messaging-message.ts
+++ b/src/models/messaging-message.ts
@@ -19,6 +19,7 @@ export interface IMessagingMessage {
 	recipientId: mongo.ObjectID;
 	isRead: boolean;
 	fileId: mongo.ObjectID;
+	uri?: string;
 }
 
 export function isValidText(text: string): boolean {

--- a/src/remote/activitypub/kernel/index.ts
+++ b/src/remote/activitypub/kernel/index.ts
@@ -1,8 +1,9 @@
-import { isCreate, isDelete, isUpdate, isFollow, isAccept, isReject, isAdd, isRemove, isAnnounce, isLike, isUndo, isBlock, isCollectionOrOrderedCollection, isCollection, IObject } from '../type';
+import { isCreate, isDelete, isUpdate, isRead, isFollow, isAccept, isReject, isAdd, isRemove, isAnnounce, isLike, isUndo, isBlock, isCollectionOrOrderedCollection, isCollection, IObject } from '../type';
 import { IRemoteUser } from '../../../models/user';
 import create from './create';
 import performDeleteActivity from './delete';
 import performUpdateActivity from './update';
+import { performReadActivity } from './read';
 import follow from './follow';
 import undo from './undo';
 import like from './like';
@@ -37,6 +38,8 @@ export async function performOneActivity(actor: IRemoteUser, activity: IObject) 
 		return await performDeleteActivity(actor, activity);
 	} else if (isUpdate(activity)) {
 		return await performUpdateActivity(actor, activity);
+	} else if (isRead(activity)) {
+		return await performReadActivity(actor, activity);
 	} else if (isFollow(activity)) {
 		return await follow(actor, activity);
 	} else if (isAccept(activity)) {

--- a/src/remote/activitypub/kernel/index.ts
+++ b/src/remote/activitypub/kernel/index.ts
@@ -21,8 +21,14 @@ export async function performActivity(actor: IRemoteUser, activity: IObject) {
 	if (isCollectionOrOrderedCollection(activity)) {
 		const resolver = new Resolver();
 		for (const item of toArray(isCollection(activity) ? activity.items : activity.orderedItems)) {
-			const act = await resolver.resolve(item);
-			await performOneActivity(actor, act);
+			try {
+				const act = await resolver.resolve(item);
+				const result = await performOneActivity(actor, act);
+				apLogger.info(`processed: ${result}`);
+			} catch (e) {
+				apLogger.warn(`failed: ${e}`);
+				continue;
+			}
 		}
 	} else {
 		return await performOneActivity(actor, activity);

--- a/src/remote/activitypub/kernel/read.ts
+++ b/src/remote/activitypub/kernel/read.ts
@@ -1,0 +1,28 @@
+import * as mongo from 'mongodb';
+import { IRemoteUser } from '../../../models/user';
+import { IRead } from '../type';
+import { isSelfHost, extractApHost } from '../../../misc/convert-host';
+import MessagingMessage from '../../../models/messaging-message';
+import readMessagingMessage from '../../../server/api/common/read-messaging-message';
+
+export const performReadActivity = async (actor: IRemoteUser, activity: IRead): Promise<string> => {
+	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
+
+	if (!isSelfHost(extractApHost(id))) {
+		return `skip: Read to foreign host (${id})`;
+	}
+
+	const messageId = new mongo.ObjectID(id.split('/').pop());
+
+	const message = await MessagingMessage.findOne({ _id: messageId });
+	if (message == null) {
+		return `skip: message not found`;
+	}
+
+	if (actor._id != message.userId) {
+		return `skip: actor is not a message owner`;
+	}
+
+	await readMessagingMessage(message.recipientId, message.userId, message._id);
+	return `ok: mark as read (${message.userId} => ${message.recipientId} ${message._id})`;
+};

--- a/src/remote/activitypub/kernel/read.ts
+++ b/src/remote/activitypub/kernel/read.ts
@@ -1,12 +1,12 @@
 import * as mongo from 'mongodb';
 import { IRemoteUser } from '../../../models/user';
-import { IRead } from '../type';
+import { IRead, getApId } from '../type';
 import { isSelfHost, extractApHost } from '../../../misc/convert-host';
 import MessagingMessage from '../../../models/messaging-message';
 import readMessagingMessage from '../../../server/api/common/read-messaging-message';
 
 export const performReadActivity = async (actor: IRemoteUser, activity: IRead): Promise<string> => {
-	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
+	const id = getApId(activity.object);
 
 	if (!isSelfHost(extractApHost(id))) {
 		return `skip: Read to foreign host (${id})`;

--- a/src/remote/activitypub/kernel/read.ts
+++ b/src/remote/activitypub/kernel/read.ts
@@ -19,8 +19,8 @@ export const performReadActivity = async (actor: IRemoteUser, activity: IRead): 
 		return `skip: message not found`;
 	}
 
-	if (actor._id != message.userId) {
-		return `skip: actor is not a message owner`;
+	if (`${actor._id}` !== `${message.recipientId}`) {
+		return `skip: actor is not a message recipient ${actor._id} ${message.recipientId}`;
 	}
 
 	await readMessagingMessage(message.recipientId, message.userId, message._id);

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -244,7 +244,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 
 	if (note._misskey_talk && visibility === 'specified') {
 		for (const recipient of visibleUsers) {
-			return await createMessage(actor, recipient, text, (files && files.length > 0) ? files[0] : undefined);
+			return await createMessage(actor, recipient, text, (files && files.length > 0) ? files[0] : undefined, object.id);
 		}
 	}
 

--- a/src/remote/activitypub/renderer/ordered-collection.ts
+++ b/src/remote/activitypub/renderer/ordered-collection.ts
@@ -6,7 +6,7 @@
  * @param last URL of last page (optional)
  * @param orderedItems attached objects (optional)
  */
-export default function(id: string, totalItems: any, first?: string, last?: string, orderedItems?: object) {
+export default function(id: string | null, totalItems: any, first?: string, last?: string, orderedItems?: object) {
 	const page: any = {
 		id,
 		type: 'OrderedCollection',

--- a/src/remote/activitypub/renderer/read.ts
+++ b/src/remote/activitypub/renderer/read.ts
@@ -1,0 +1,9 @@
+import config from '../../../config';
+import { ILocalUser } from '../../../models/user';
+import * as mongo from 'mongodb';
+
+export const renderReadActivity = (user: ILocalUser, messageId: mongo.ObjectID) => ({
+	type: 'Read',
+	actor: `${config.url}/users/${user._id}`,
+	object: `${config.url}/notes/${messageId}`
+});

--- a/src/remote/activitypub/renderer/read.ts
+++ b/src/remote/activitypub/renderer/read.ts
@@ -1,9 +1,9 @@
 import config from '../../../config';
 import { ILocalUser } from '../../../models/user';
-import * as mongo from 'mongodb';
+import { IMessagingMessage } from '../../../models/messaging-message';
 
-export const renderReadActivity = (user: ILocalUser, messageId: mongo.ObjectID) => ({
+export const renderReadActivity = (user: ILocalUser, message: IMessagingMessage) => ({
 	type: 'Read',
 	actor: `${config.url}/users/${user._id}`,
-	object: `${config.url}/notes/${messageId}`
+	object: message.uri
 });

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -233,6 +233,10 @@ export interface IUpdate extends IActivity {
 	type: 'Update';
 }
 
+export interface IRead extends IActivity {
+	type: 'Read';
+}
+
 export interface IUndo extends IActivity {
 	type: 'Undo';
 }
@@ -273,6 +277,7 @@ export interface IBlock extends IActivity {
 export const isCreate = (object: IObject): object is ICreate => object.type === 'Create';
 export const isDelete = (object: IObject): object is IDelete => object.type === 'Delete';
 export const isUpdate = (object: IObject): object is IUpdate => object.type === 'Update';
+export const isRead = (object: IObject): object is IRead => object.type === 'Read';
 export const isUndo = (object: IObject): object is IUndo => object.type === 'Undo';
 export const isFollow = (object: IObject): object is IFollow => object.type === 'Follow';
 export const isAccept = (object: IObject): object is IAccept => object.type === 'Accept';

--- a/src/server/api/endpoints/messaging/messages.ts
+++ b/src/server/api/endpoints/messaging/messages.ts
@@ -1,7 +1,7 @@
 import $ from 'cafy';
 import ID, { transform } from '../../../../misc/cafy-id';
 import Message from '../../../../models/messaging-message';
-import MessagingMessage, { pack } from '../../../../models/messaging-message';
+import { pack } from '../../../../models/messaging-message';
 import read, { deliverReadActivity } from '../../common/read-messaging-message';
 import define from '../../define';
 import { ApiError } from '../../error';
@@ -111,7 +111,7 @@ export default define(meta, async (ps, user) => {
 
 		// リモートユーザーとのメッセージだったら既読配信
 		if (isLocalUser(user) && isRemoteUser(recipient)) {
-			deliverReadActivity(user, recipient, messages.map(x => x._id));
+			deliverReadActivity(user, recipient, messages);
 		}
 	}
 

--- a/src/server/api/endpoints/messaging/messages.ts
+++ b/src/server/api/endpoints/messaging/messages.ts
@@ -1,11 +1,12 @@
 import $ from 'cafy';
 import ID, { transform } from '../../../../misc/cafy-id';
 import Message from '../../../../models/messaging-message';
-import { pack } from '../../../../models/messaging-message';
-import read from '../../common/read-messaging-message';
+import MessagingMessage, { pack } from '../../../../models/messaging-message';
+import read, { deliverReadActivity } from '../../common/read-messaging-message';
 import define from '../../define';
 import { ApiError } from '../../error';
 import { getUser } from '../../common/getters';
+import { isLocalUser, isRemoteUser } from '../../../../models/user';
 
 export const meta = {
 	desc: {
@@ -107,6 +108,11 @@ export default define(meta, async (ps, user) => {
 	// Mark all as read
 	if (ps.markAsRead) {
 		read(user._id, recipient._id, messages);
+
+		// リモートユーザーとのメッセージだったら既読配信
+		if (isLocalUser(user) && isRemoteUser(recipient)) {
+			deliverReadActivity(user, recipient, messages.map(x => x._id));
+		}
 	}
 
 	return await Promise.all(messages.map(message => pack(message, user, {

--- a/src/server/api/stream/channels/messaging.ts
+++ b/src/server/api/stream/channels/messaging.ts
@@ -1,6 +1,7 @@
 import autobind from 'autobind-decorator';
-import read from '../../common/read-messaging-message';
+import read, { deliverReadActivity } from '../../common/read-messaging-message';
 import Channel from '../channel';
+import User, { isRemoteUser, IUser, isLocalUser } from '../../../../models/user';
 
 export default class extends Channel {
 	public readonly chName = 'messaging';
@@ -8,10 +9,12 @@ export default class extends Channel {
 	public static requireCredential = true;
 
 	private otherpartyId: string;
+	private otherparty: IUser;
 
 	@autobind
 	public async init(params: any) {
 		this.otherpartyId = params.otherparty as string;
+		this.otherparty = await User.findOne({ _id: this.otherpartyId});
 
 		// Subscribe messaging stream
 		this.subscriber.on(`messagingStream:${this.user._id}-${this.otherpartyId}`, data => {
@@ -24,6 +27,11 @@ export default class extends Channel {
 		switch (type) {
 			case 'read':
 				read(this.user._id, this.otherpartyId, body.id);
+
+				// リモートユーザーからのメッセージだったら既読配信
+				if (isLocalUser(this.user) && isRemoteUser(this.otherparty)) {
+					deliverReadActivity(this.user, this.otherparty, body.id);
+				}
 				break;
 		}
 	}

--- a/src/server/api/stream/channels/messaging.ts
+++ b/src/server/api/stream/channels/messaging.ts
@@ -1,7 +1,8 @@
 import autobind from 'autobind-decorator';
 import read, { deliverReadActivity } from '../../common/read-messaging-message';
 import Channel from '../channel';
-import User, { isRemoteUser, IUser, isLocalUser } from '../../../../models/user';
+import User, { isRemoteUser, IUser, isLocalUser, ILocalUser, IRemoteUser } from '../../../../models/user';
+import MessagingMessage from '../../../../models/messaging-message';
 
 export default class extends Channel {
 	public readonly chName = 'messaging';
@@ -30,7 +31,9 @@ export default class extends Channel {
 
 				// リモートユーザーからのメッセージだったら既読配信
 				if (isLocalUser(this.user) && isRemoteUser(this.otherparty)) {
-					deliverReadActivity(this.user, this.otherparty, body.id);
+					MessagingMessage.findOne({ _id: body.id }).then(message => {
+						deliverReadActivity(this.user as ILocalUser, this.otherparty as IRemoteUser, message);
+					});
 				}
 				break;
 		}

--- a/src/services/messages/create.ts
+++ b/src/services/messages/create.ts
@@ -10,14 +10,15 @@ import renderCreate from '../../remote/activitypub/renderer/create';
 import { renderActivity } from '../../remote/activitypub/renderer';
 import { deliver } from '../../queue';
 
-export async function createMessage(user: IUser, recipient: IUser, text: string, file: IDriveFile) {
+export async function createMessage(user: IUser, recipient: IUser, text: string, file: IDriveFile, uri?: string) {
 	const message = await MessagingMessage.insert({
 		createdAt: new Date(),
 		fileId: file ? file._id : undefined,
 		recipientId: recipient._id,
 		text: text ? text.trim() : undefined,
 		userId: user._id,
-		isRead: false
+		isRead: false,
+		uri,
 	});
 
 	const messageObj = await packMessage(message);


### PR DESCRIPTION
## Summary
Resolve #473

インスタンス間のトークの既読処理をRead Activityで実装
※ Read Activity https://www.w3.org/TR/activitystreams-vocabulary/#dfn-read

- Talkが送られてきたらActivity idをuriとして保存しておく
- 既読にした時に相手がリモートでuri取得済みだったらRead Activityを送る
- Read Activityを受け取ったら既読処理を行う
- 複数の既読通知はCollection Activityとしてまとめて送る

v11: syuilo#5636