### PR TITLE
API Permissionの挙動をv11に近づける

### DIFF
--- a/src/server/api/call.ts
+++ b/src/server/api/call.ts
@@ -5,6 +5,7 @@ import { IApp } from '../../models/app';
 import endpoints from './endpoints';
 import { ApiError } from './error';
 import { apiLogger } from './logger';
+import { toArray } from '../../prelude/array';
 
 const accessDenied = {
 	message: 'Access denied.',
@@ -51,7 +52,7 @@ export default async (endpoint: string, user: IUser, app: IApp, data: any, file?
 		throw new ApiError(accessDenied, { reason: 'You are not a moderator.' });
 	}
 
-	if (app && ep.meta.kind && !app.permission.some(p => p === ep.meta.kind)) {
+	if (app && ep.meta.kind && !app.permission.some(p => toArray(ep.meta.kind).includes(p))) {
 		throw new ApiError({
 			message: 'Your app does not have the necessary permissions to use this endpoint.',
 			code: 'PERMISSION_DENIED',

--- a/src/server/api/endpoints.ts
+++ b/src/server/api/endpoints.ts
@@ -105,7 +105,7 @@ export interface IEndpointMeta {
 	 * エンドポイントの種類
 	 * パーミッションの実現に利用されます。
 	 */
-	kind?: string;
+	kind?: string | string[];
 }
 
 export interface IEndpoint {

--- a/src/server/api/endpoints/app/create.ts
+++ b/src/server/api/endpoints/app/create.ts
@@ -36,6 +36,7 @@ export default define(meta, async (ps, user) => {
 
 	let p = ps.permission;
 
+	/*
 	p = p.map(x => x
 		// v11 => v10
 		.replace('read:account', 'account-read')
@@ -55,14 +56,17 @@ export default define(meta, async (ps, user) => {
 		.replace('write:reactions', 'reaction-write')
 		.replace('write:votes', 'vote-write')
 	);
+	*/
 
 	// v10 typos
+	/*
 	if (p.includes('favorites-read')) p.push('favorite-read');
 	if (p.includes('favorite-read')) p.push('favorites-read');
 	if (p.includes('account/read')) p.push('account-read');
 	if (p.includes('account-read')) p.push('account/read');
 	if (p.includes('account/write')) p.push('account-write');
 	if (p.includes('account-write')) p.push('account/write');
+	*/
 
 	// 今のv10にはなし
 	// 'note-read', 'vote-read',

--- a/src/server/api/endpoints/blocking/create.ts
+++ b/src/server/api/endpoints/blocking/create.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/blocking/delete.ts
+++ b/src/server/api/endpoints/blocking/delete.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/blocking/list.ts
+++ b/src/server/api/endpoints/blocking/list.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-read',
+	kind: ['read:following', 'following-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/drive.ts
+++ b/src/server/api/endpoints/drive.ts
@@ -12,7 +12,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	res: {
 		type: 'object',

--- a/src/server/api/endpoints/drive/files.ts
+++ b/src/server/api/endpoints/drive/files.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/drive/files/attached-notes.ts
+++ b/src/server/api/endpoints/drive/files/attached-notes.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		fileId: {

--- a/src/server/api/endpoints/drive/files/check-existence.ts
+++ b/src/server/api/endpoints/drive/files/check-existence.ts
@@ -12,7 +12,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		md5: {

--- a/src/server/api/endpoints/drive/files/create.ts
+++ b/src/server/api/endpoints/drive/files/create.ts
@@ -24,7 +24,7 @@ export const meta = {
 
 	requireFile: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		folderId: {

--- a/src/server/api/endpoints/drive/files/delete.ts
+++ b/src/server/api/endpoints/drive/files/delete.ts
@@ -18,7 +18,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		fileId: {

--- a/src/server/api/endpoints/drive/files/find.ts
+++ b/src/server/api/endpoints/drive/files/find.ts
@@ -8,7 +8,7 @@ export const meta = {
 
 	tags: ['drive'],
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		name: {

--- a/src/server/api/endpoints/drive/files/show.ts
+++ b/src/server/api/endpoints/drive/files/show.ts
@@ -18,7 +18,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		fileId: {

--- a/src/server/api/endpoints/drive/files/update.ts
+++ b/src/server/api/endpoints/drive/files/update.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		fileId: {

--- a/src/server/api/endpoints/drive/files/upload-from-url.ts
+++ b/src/server/api/endpoints/drive/files/upload-from-url.ts
@@ -19,7 +19,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		url: {

--- a/src/server/api/endpoints/drive/folders.ts
+++ b/src/server/api/endpoints/drive/folders.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/drive/folders/create.ts
+++ b/src/server/api/endpoints/drive/folders/create.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		name: {

--- a/src/server/api/endpoints/drive/folders/delete.ts
+++ b/src/server/api/endpoints/drive/folders/delete.ts
@@ -18,7 +18,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		folderId: {

--- a/src/server/api/endpoints/drive/folders/find.ts
+++ b/src/server/api/endpoints/drive/folders/find.ts
@@ -8,7 +8,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		name: {

--- a/src/server/api/endpoints/drive/folders/show.ts
+++ b/src/server/api/endpoints/drive/folders/show.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		folderId: {

--- a/src/server/api/endpoints/drive/folders/update.ts
+++ b/src/server/api/endpoints/drive/folders/update.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-write',
+	kind: ['write:drive', 'drive-write'],
 
 	params: {
 		folderId: {

--- a/src/server/api/endpoints/drive/stream.ts
+++ b/src/server/api/endpoints/drive/stream.ts
@@ -8,7 +8,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'drive-read',
+	kind: ['read:drive', 'drive-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/following/create.ts
+++ b/src/server/api/endpoints/following/create.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/following/delete.ts
+++ b/src/server/api/endpoints/following/delete.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/following/requests/accept.ts
+++ b/src/server/api/endpoints/following/requests/accept.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/following/requests/cancel.ts
+++ b/src/server/api/endpoints/following/requests/cancel.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/following/requests/list.ts
+++ b/src/server/api/endpoints/following/requests/list.ts
@@ -11,7 +11,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-read'
+	kind: ['read:following', 'following-read'],
 };
 
 export default define(meta, async (ps, user) => {

--- a/src/server/api/endpoints/following/requests/reject.ts
+++ b/src/server/api/endpoints/following/requests/reject.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'following-write',
+	kind: ['write:following', 'following-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/i/clear-follow-request-notification.ts
+++ b/src/server/api/endpoints/i/clear-follow-request-notification.ts
@@ -6,7 +6,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 	}

--- a/src/server/api/endpoints/i/clear-follow-request-notification.ts
+++ b/src/server/api/endpoints/i/clear-follow-request-notification.ts
@@ -6,7 +6,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 	}

--- a/src/server/api/endpoints/i/favorites.ts
+++ b/src/server/api/endpoints/i/favorites.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'favorites-read',
+	kind: ['read:favorites', 'favorite-read', 'favorites-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/i/notifications.ts
+++ b/src/server/api/endpoints/i/notifications.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/i/page-likes.ts
+++ b/src/server/api/endpoints/i/page-likes.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'favorites-read',
+	kind: ['read:favorites', 'favorite-read', 'favorites-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/i/pages.ts
+++ b/src/server/api/endpoints/i/pages.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/i/pin.ts
+++ b/src/server/api/endpoints/i/pin.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/i/pin.ts
+++ b/src/server/api/endpoints/i/pin.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/i/read-all-messaging-messages.ts
+++ b/src/server/api/endpoints/i/read-all-messaging-messages.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 	}

--- a/src/server/api/endpoints/i/read-all-messaging-messages.ts
+++ b/src/server/api/endpoints/i/read-all-messaging-messages.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 	}

--- a/src/server/api/endpoints/i/read-all-unread-notes.ts
+++ b/src/server/api/endpoints/i/read-all-unread-notes.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 	}

--- a/src/server/api/endpoints/i/read-all-unread-notes.ts
+++ b/src/server/api/endpoints/i/read-all-unread-notes.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 	}

--- a/src/server/api/endpoints/i/unpin.ts
+++ b/src/server/api/endpoints/i/unpin.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/i/unpin.ts
+++ b/src/server/api/endpoints/i/unpin.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		name: {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		name: {

--- a/src/server/api/endpoints/messaging/history.ts
+++ b/src/server/api/endpoints/messaging/history.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'messaging-read',
+	kind: ['read:messaging', 'messaging-read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/messaging/messages.ts
+++ b/src/server/api/endpoints/messaging/messages.ts
@@ -18,7 +18,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'messaging-read',
+	kind: ['read:messaging', 'messaging-read'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/messaging/messages/create.ts
+++ b/src/server/api/endpoints/messaging/messages/create.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'messaging-write',
+	kind: ['write:messaging', 'messaging-write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/messaging/messages/delete.ts
+++ b/src/server/api/endpoints/messaging/messages/delete.ts
@@ -18,7 +18,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'messaging-write',
+	kind: ['write:messaging', 'messaging-write'],
 
 	limit: {
 		duration: ms('1hour'),

--- a/src/server/api/endpoints/messaging/messages/read.ts
+++ b/src/server/api/endpoints/messaging/messages/read.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'messaging-write',
+	kind: ['write:messaging', 'messaging-write'],
 
 	params: {
 		messageId: {

--- a/src/server/api/endpoints/mute/create.ts
+++ b/src/server/api/endpoints/mute/create.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account/write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/mute/create.ts
+++ b/src/server/api/endpoints/mute/create.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/mute/delete.ts
+++ b/src/server/api/endpoints/mute/delete.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account/write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/mute/delete.ts
+++ b/src/server/api/endpoints/mute/delete.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/mute/list.ts
+++ b/src/server/api/endpoints/mute/list.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account/read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -34,7 +34,7 @@ export const meta = {
 		max: 300
 	},
 
-	kind: 'note-write',
+	kind: ['write:notes', 'note-write'],
 
 	params: {
 		visibility: {

--- a/src/server/api/endpoints/notes/delete.ts
+++ b/src/server/api/endpoints/notes/delete.ts
@@ -18,7 +18,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'note-write',
+	kind: ['write:notes', 'note-write'],
 
 	limit: {
 		minInterval: 500

--- a/src/server/api/endpoints/notes/favorites/create.ts
+++ b/src/server/api/endpoints/notes/favorites/create.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'favorite-write',
+	kind: ['write:favorites', 'favorite-write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/favorites/delete.ts
+++ b/src/server/api/endpoints/notes/favorites/delete.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'favorite-write',
+	kind: ['write:favorites', 'favorite-write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/polls/vote.ts
+++ b/src/server/api/endpoints/notes/polls/vote.ts
@@ -25,7 +25,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'vote-write',
+	kind: ['write:votes', 'vote-write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/reactions/create.ts
+++ b/src/server/api/endpoints/notes/reactions/create.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'reaction-write',
+	kind: ['write:reactions', 'reaction-write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/reactions/delete.ts
+++ b/src/server/api/endpoints/notes/reactions/delete.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'reaction-write',
+	kind: ['write:reactions', 'reaction-write'],
 
 	limit: {
 		minInterval: 500

--- a/src/server/api/endpoints/notes/watching/create.ts
+++ b/src/server/api/endpoints/notes/watching/create.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/watching/create.ts
+++ b/src/server/api/endpoints/notes/watching/create.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/watching/delete-all.ts
+++ b/src/server/api/endpoints/notes/watching/delete-all.ts
@@ -11,7 +11,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 	},

--- a/src/server/api/endpoints/notes/watching/delete-all.ts
+++ b/src/server/api/endpoints/notes/watching/delete-all.ts
@@ -11,7 +11,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 	},

--- a/src/server/api/endpoints/notes/watching/delete.ts
+++ b/src/server/api/endpoints/notes/watching/delete.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/notes/watching/delete.ts
+++ b/src/server/api/endpoints/notes/watching/delete.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		noteId: {

--- a/src/server/api/endpoints/pages/create.ts
+++ b/src/server/api/endpoints/pages/create.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'note-write',
+	kind: ['write:notes', 'note-write'],
 
 	limit: {
 		duration: ms('1hour'),

--- a/src/server/api/endpoints/pages/delete.ts
+++ b/src/server/api/endpoints/pages/delete.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'note-write',
+	kind: ['write:notes', 'note-write'],
 
 	params: {
 		pageId: {

--- a/src/server/api/endpoints/pages/like.ts
+++ b/src/server/api/endpoints/pages/like.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'favorite-write',
+	kind: ['write:favorites', 'favorite-write'],
 
 	params: {
 		pageId: {

--- a/src/server/api/endpoints/pages/unlike.ts
+++ b/src/server/api/endpoints/pages/unlike.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'favorite-write',
+	kind: ['write:favorites', 'favorite-write'],
 
 	params: {
 		pageId: {

--- a/src/server/api/endpoints/pages/update.ts
+++ b/src/server/api/endpoints/pages/update.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'note-write',
+	kind: ['write:notes', 'note-write'],
 
 	params: {
 		pageId: {

--- a/src/server/api/endpoints/user-filter/list.ts
+++ b/src/server/api/endpoints/user-filter/list.ts
@@ -13,7 +13,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account/read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		type: {

--- a/src/server/api/endpoints/user-filter/update.ts
+++ b/src/server/api/endpoints/user-filter/update.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		targetId: {

--- a/src/server/api/endpoints/user-filter/update.ts
+++ b/src/server/api/endpoints/user-filter/update.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account/write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		targetId: {

--- a/src/server/api/endpoints/users/lists/create.ts
+++ b/src/server/api/endpoints/users/lists/create.ts
@@ -12,7 +12,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		title: {

--- a/src/server/api/endpoints/users/lists/create.ts
+++ b/src/server/api/endpoints/users/lists/create.ts
@@ -12,7 +12,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		title: {

--- a/src/server/api/endpoints/users/lists/delete.ts
+++ b/src/server/api/endpoints/users/lists/delete.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/delete.ts
+++ b/src/server/api/endpoints/users/lists/delete.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/list.ts
+++ b/src/server/api/endpoints/users/lists/list.ts
@@ -12,7 +12,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/users/lists/pull-host.ts
+++ b/src/server/api/endpoints/users/lists/pull-host.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/pull-host.ts
+++ b/src/server/api/endpoints/users/lists/pull-host.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/pull.ts
+++ b/src/server/api/endpoints/users/lists/pull.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/pull.ts
+++ b/src/server/api/endpoints/users/lists/pull.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/push-host.ts
+++ b/src/server/api/endpoints/users/lists/push-host.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/push-host.ts
+++ b/src/server/api/endpoints/users/lists/push-host.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/push.ts
+++ b/src/server/api/endpoints/users/lists/push.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/push.ts
+++ b/src/server/api/endpoints/users/lists/push.ts
@@ -17,7 +17,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/show.ts
+++ b/src/server/api/endpoints/users/lists/show.ts
@@ -14,7 +14,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/update.ts
+++ b/src/server/api/endpoints/users/lists/update.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: 'account-write',
+	kind: ['write:account', 'account-write', account/write],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/lists/update.ts
+++ b/src/server/api/endpoints/users/lists/update.ts
@@ -15,7 +15,7 @@ export const meta = {
 
 	requireCredential: true,
 
-	kind: ['write:account', 'account-write', account/write],
+	kind: ['write:account', 'account-write', 'account/write'],
 
 	params: {
 		listId: {

--- a/src/server/api/endpoints/users/recommendation.ts
+++ b/src/server/api/endpoints/users/recommendation.ts
@@ -16,7 +16,7 @@ export const meta = {
 
 	requireCredential: false,
 
-	kind: 'account-read',
+	kind: ['read:account', 'account-read', 'account/read'],
 
 	params: {
 		limit: {


### PR DESCRIPTION
## Summary
要求されたPermissionのみを許可して、
v10/v11/typo PermissionはendpointのkindをArrayで複数許可するようにして吸収
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
