### PR TITLE
CIではproductionビルドをするようになど

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn install
+    - run: NODE_ENV=production yarn install
     - run: cp .circleci/misskey/*.yml .config/
-    - run: yarn build
+    - run: NODE_ENV=production yarn build
     - run: yarn test 


### PR DESCRIPTION
## Summary
一部ちゃんと`devDependencies`を分けるようにしたので、ミスを検出しやすくするためCIもproductionでビルドするように。
Dockerとの整合性も合わせるために。
あとproductionでだけoptimizeがコケることがあるのでそれを見つけやすくするために。

またNode v13はEOLなのでCIも廃止。
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
