### PR TITLE
CIでメモリなどの情報を表示するように

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: node cli/diag-environment.js
     - run: NODE_ENV=production yarn install
     - run: cp .circleci/misskey/*.yml .config/
     - run: NODE_ENV=production yarn build

--- a/cli/diag-environment.js
+++ b/cli/diag-environment.js
@@ -1,0 +1,11 @@
+"use strict";
+const process = require("process");
+const os = require("os");
+const v8 = require("v8");
+console.log(`Node Version: ${process.version}`);
+console.log(`Node ExecPath: ${process.execPath}`);
+console.log(`OS Platform: ${os.platform()}`);
+console.log(`OS Arch: ${os.arch()}`);
+console.log(`vCPU: ${os.cpus().length}`);
+console.log(`TotalMem: ${Math.floor(os.totalmem() / 1024 / 1024)} MiB`);
+console.log(`HeapSizeLimit: ${Math.floor(v8.getHeapStatistics().heap_size_limit / 1024 / 1024)} MiB`);

--- a/src/tools/diag-environment.ts
+++ b/src/tools/diag-environment.ts
@@ -1,0 +1,11 @@
+import * as process from 'process';
+import * as os from 'os';
+import * as v8 from 'v8';
+
+console.log(`Node Version: ${process.version}`);
+console.log(`Node ExecPath: ${process.execPath}`);
+console.log(`OS Platform: ${os.platform()}`);
+console.log(`OS Arch: ${os.arch()}`);
+console.log(`vCPU: ${os.cpus().length}`);
+console.log(`TotalMem: ${Math.floor(os.totalmem() / 1024 / 1024)} MiB`);
+console.log(`HeapSizeLimit: ${Math.floor(v8.getHeapStatistics().heap_size_limit / 1024 / 1024)} MiB`);


### PR DESCRIPTION
## Summary

主にビルドのトラブルシューティングのために診断用のコマンドを追加
```
$ node cli/diag-environment.js 
Node Version: v14.15.1
Node ExecPath: /home/user/.anyenv/envs/nodenv/versions/14.15.1/bin/node
OS Platform: linux
OS Arch: x64
vCPU: 4
TotalMem: 7833 MiB
HeapSizeLimit: 2096 MiB
```

CIでビルド前にそのコマンドを実行するように