### PR TITLE
Resolve #2090

### DIFF
--- a/src/mfm/to-html.ts
+++ b/src/mfm/to-html.ts
@@ -4,7 +4,7 @@ import { INote } from '../models/note';
 import { concat } from '../prelude/array';
 import { MfmForest, MfmTree } from './prelude';
 
-export function toHtml(tokens: MfmForest, mentionedRemoteUsers: INote['mentionedRemoteUsers'] = []) {
+export function toHtml(tokens: MfmForest | null, mentionedRemoteUsers: INote['mentionedRemoteUsers'] = []) {
 	if (tokens == null) {
 		return null;
 	}


### PR DESCRIPTION
## Summary
Resolve #2090

Noteエンティティとしてtext (MFM)だけではなく html (HTML) も返すようにして、マークアップ＆文字装飾を分離出来るようにする。
サードパーティアプリがMastdonの`content`をパースするのと同様の実装をすれば、MFMの文字装飾を無視してとりあえず表示できるようにする。

Note.text (MFM)
```
@a #あ https://example.com あああ [spin あ]
```

Note.html (HTML)
```html
<p><a href="https://mk10.example.com/@a" class="u-url mention">@a</a><span> </span>
<a href="https://mk10.example.com/tags/あ" rel="tag">#あ</a><span> </span>
<a href="https://example.com">https://example.com</a><span><br>あああ<br></span>
<span data-mfm="spin"><span>あ</span></span></p>
```

空投稿は`html: "<p></p>"`を返すのでhtmlプロパティがないということはそのインスタンスが未対応ということ。