### PR TITLE
引用拒否とRenote/引用を相手に通知しないオプション

### DIFF
--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -61,6 +61,7 @@ export type INote = {
 	viaMobile: boolean;
 	localOnly: boolean;
 	copyOnce?: boolean;
+	quoteProhibited?: boolean;
 	renoteCount: number;
 	repliesCount: number;
 	reactionCounts: Record<string, number>;

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -256,6 +256,8 @@ export async function createNote(value: string | IObject, resolver?: Resolver | 
 		text,
 		viaMobile: false,
 		localOnly: false,
+		notifyToOwner: !!note.notifyToOwner,
+		quoteProhibited: !!note.quoteProhibited,
 		geo: undefined,
 		visibility,
 		visibleUsers,

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -45,6 +45,8 @@ export const attachLdSignature = async (activity: any, user: ILocalUser): Promis
 		'_misskey_votes': 'misskey:_misskey_votes',
 		'_misskey_talk': 'misskey:_misskey_talk',
 		'isCat': 'misskey:isCat',
+		'notifyToOwner': 'misskey:notifyToOwner',
+		'quoteProhibited': 'misskey:quoteProhibited',
 		// vcard
 		vcard: 'http://www.w3.org/2006/vcard/ns#',
 	};

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -130,6 +130,8 @@ export interface IPost extends IObject {
 	_misskey_quote?: string;
 	quoteUrl?: string;
 	_misskey_talk?: boolean;
+	notifyToOwner?: boolean;
+	quoteProhibited?: boolean;
 }
 
 export const validPost = ['Note', 'Question', 'Article', 'Audio', 'Document', 'Image', 'Page', 'Video', 'Event'];

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -94,6 +94,22 @@ export const meta = {
 			}
 		},
 
+		notifyToOwner: {
+			validator: $.optional.bool,
+			default: true,
+			desc: {
+				'ja-JP': 'Renote/Quoteをその投稿の所有者に通知するか'
+			}
+		},
+
+		quoteProhibited: {
+			validator: $.optional.bool,
+			default: true,
+			desc: {
+				'ja-JP': 'Quoteを拒否するか'
+			}
+		},
+
 		noExtractMentions: {
 			validator: $.optional.bool,
 			default: false,
@@ -343,6 +359,8 @@ export default define(meta, async (ps, user, app) => {
 		viaMobile: ps.viaMobile,
 		localOnly: ps.localOnly,
 		copyOnce: ps.copyOnce,
+		notifyToOwner: ps.notifyToOwner,
+		quoteProhibited: ps.quoteProhibited,
 		visibility: ps.visibility,
 		visibleUsers,
 		apMentions: ps.noExtractMentions ? [] : undefined,

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -113,6 +113,8 @@ type Option = {
 	viaMobile?: boolean;
 	localOnly?: boolean;
 	copyOnce?: boolean;
+	notifyToOwner?: boolean;
+	quoteProhibited?: boolean;
 	cw?: string;
 	visibility?: string;
 	visibleUsers?: IUser[];
@@ -176,6 +178,10 @@ export default async (user: IUser, data: Option, silent = false) => {
 	// PureRenoteの最大公開範囲はHomeにする
 	if (isPureRenote && data.visibility === 'public') {
 		data.visibility = 'home';
+	}
+
+	if (data.renote && !isPureRenote && data.quoteProhibited) {
+		throw 'quote prohibited';
 	}
 
 	// ローカルのみをRenoteしたらローカルのみにする
@@ -365,7 +371,7 @@ export default async (user: IUser, data: Option, silent = false) => {
 			const type = data.text ? 'quote' : 'renote';
 
 			// Notify
-			if (isLocalUser(data.renote._user)) {
+			if (isLocalUser(data.renote._user && data.notifyToOwner)) {
 				nm.push(data.renote.userId, type);
 			}
 
@@ -414,7 +420,7 @@ export default async (user: IUser, data: Option, silent = false) => {
 					}
 
 					// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
-					if (data.renote && isRemoteUser(data.renote._user)) {
+					if (data.renote && isRemoteUser(data.renote._user) && data.notifyToOwner) {
 						dm.addDirectRecipe(data.renote._user);
 					}
 
@@ -502,6 +508,7 @@ async function insertNote(user: IUser, data: Option, tags: string[], emojis: str
 		viaMobile: data.viaMobile,
 		localOnly: data.localOnly,
 		copyOnce: data.copyOnce,
+		quoteProhibited: data.quoteProhibited,
 		geo: data.geo || null,
 		appId: data.app ? data.app._id : null,
 		visibility: data.visibility,


### PR DESCRIPTION
## Summary
引用拒否とRenote/引用を相手に通知しないオプション

コミュニケーションのごたごたを機能のせいにされないようにする。
相手が対応してないと意味がなく連合の不整合を増大させるだけなのは百も承知で、それは今に始まった話ではない。