### PR TITLE
following/followers APIのv11互換

### DIFF
--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -132,7 +132,7 @@ export type PackedUser = ThinPackedUser & {
 	// my secrets
 	email?: string | null;
 	emailVerified?: boolean;
-	clientSettings: any;
+	clientSettings?: any;
 	settings?: {
 		autoWatch: boolean;
 		alwaysMarkNsfw?: boolean;

--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -156,6 +156,7 @@ export type PackedUser = ThinPackedUser & {
 	*/
 }
 
+//#region Follow
 export type PackedFollowBase = {
 	/** Relation ID */
 	id: string;
@@ -169,16 +170,25 @@ export type PackedFollowBase = {
 
 export type PackedFollowee = PackedFollowBase & {
 	/** フォローされたユーザーのオブジェクト */
-	followee?: PackedUser | null;
+	followee: PackedUser;
 };
 
-export type PackedFollowees = PackedFollowee[];
+export type PackedFollower = PackedFollowBase & {
+	/** フォローしているユーザーのオブジェクト */
+	follower: PackedUser;
+};
 
 export type V10Followees = {
-	/** フォローしているユーザーオブジェクト */
-	users: (PackedUser | null)[];
+	/** フォローしているユーザーのオブジェクト */
+	users: PackedUser[];
 	/** 返した中で最後のRelation ID (nextという名前だけどnextではない！) */
 	next: string
 }
 
-export type Followees = V10Followees | PackedFollowees;
+export type V10Followers = {
+	/** フォローされたユーザーのオブジェクト */
+	users: PackedUser[];
+	/** 返した中で最後のRelation ID (nextという名前だけどnextではない！) */
+	next: string
+}
+//#endregion

--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -155,3 +155,30 @@ export type PackedUser = ThinPackedUser & {
 	hasUnreadAnnouncement?: boolean;
 	*/
 }
+
+export type PackedFollowBase = {
+	/** Relation ID */
+	id: string;
+	/** フォローの作成日時 */
+	createdAt: string | null;
+	/** フォローされたユーザーのID */
+	followeeId: string;
+	/** フォローしたユーザーのID */
+	followerId: string;
+}
+
+export type PackedFollowee = PackedFollowBase & {
+	/** フォローされたユーザーのオブジェクト */
+	followee?: PackedUser | null;
+};
+
+export type PackedFollowees = PackedFollowee[];
+
+export type V10Followees = {
+	/** フォローしているユーザーオブジェクト */
+	users: (PackedUser | null)[];
+	/** 返した中で最後のRelation ID (nextという名前だけどnextではない！) */
+	next: string
+}
+
+export type Followees = V10Followees | PackedFollowees;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,3 +1,4 @@
+// tslint:disable: use-type-alias
 import * as mongo from 'mongodb';
 import * as deepcopy from 'deepcopy';
 import db from '../db/mongodb';
@@ -323,6 +324,22 @@ export async function getRelation(me: mongo.ObjectId, target: mongo.ObjectId) {
 	};
 }
 
+type PackOptions = {
+	detail?: boolean,
+	includeSecrets?: boolean,
+	includeHasUnreadNotes?: boolean
+};
+
+export async function pack(
+	src: IUser,
+	me?: string | mongo.ObjectID | IUser | null,
+	options?: PackOptions
+): Promise<PackedUser>;
+export async function pack(
+	src: string | mongo.ObjectID,
+	me?: string | mongo.ObjectID | IUser | null,
+	options?: PackOptions
+): Promise<PackedUser | null>;
 /**
  * Pack a user for API response
  *
@@ -331,15 +348,11 @@ export async function getRelation(me: mongo.ObjectId, target: mongo.ObjectId) {
  * @param options? serialize options
  * @return Packed user
  */
-export const pack = async (
+export async function pack(
 	src: string | mongo.ObjectID | IUser,
 	me?: string | mongo.ObjectID | IUser | null,
-	options?: {
-		detail?: boolean,
-		includeSecrets?: boolean,
-		includeHasUnreadNotes?: boolean
-	}
-): Promise<PackedUser | null> => {
+	options?: PackOptions
+): Promise<PackedUser | null> {
 	const opts = Object.assign({
 		detail: false,
 		includeSecrets: false

--- a/src/server/api/endpoints/users/followers.ts
+++ b/src/server/api/endpoints/users/followers.ts
@@ -225,6 +225,6 @@ export default define(meta, async (ps, me) => {
 			};
 		}
 
-		return await Promise.all(following.map(x => packFollower));
+		return await Promise.all(following.map(x => packFollower(x)));
 	}
 });

--- a/src/server/api/endpoints/users/followers.ts
+++ b/src/server/api/endpoints/users/followers.ts
@@ -1,12 +1,14 @@
 import $ from 'cafy';
 import ID, { transform } from '../../../../misc/cafy-id';
-import User, { IUser } from '../../../../models/user';
+import User, { IUser, ILocalUser, pack as packUser } from '../../../../models/user';
 import Following, { IFollowing } from '../../../../models/following';
 import { pack } from '../../../../models/user';
 import { getFriendIds } from '../../common/get-friends';
 import define from '../../define';
 import { ApiError } from '../../error';
 import { canShowFollows } from '../../common/can-show-follows';
+import { PackedFollower } from '../../../../models/packed-schemas';
+import { toOidString, toISODateOrNull } from '../../../../misc/pack-utils';
 
 export const meta = {
 	desc: {
@@ -45,6 +47,33 @@ export const meta = {
 			validator: $.optional.type(ID),
 			default: null as any,
 			transform: transform,
+			desc: {
+				'ja-JP': '指定すると、このIDより過去のレコードを取得します。'
+			}
+		},
+
+		sinceId: {
+			validator: $.optional.type(ID),
+			transform: transform,
+			desc: {
+				'ja-JP': '[v11-互換] 指定すると、このIDより未来のレコードを取得します。またEntiryがv11互換に変わります。またソート順が逆になります。'
+			}
+		},
+
+		untilId: {
+			validator: $.optional.type(ID),
+			transform: transform,
+			desc: {
+				'ja-JP': '[v11-互換] 指定すると、このIDより過去のレコードを取得します。またEntiryがv11互換に変わります。'
+			}
+		},
+
+		v11compatible: {
+			validator: $.optional.bool,
+			default: false,
+			desc: {
+				'ja-JP': '[v11-互換] 指定すると、Entiryがv11互換に変わります。'
+			}
 		},
 
 		iknow: {
@@ -129,11 +158,27 @@ export default define(meta, async (ps, me) => {
 
 	// TODO: iknow && diff
 
+	const sort = {
+		_id: -1
+	};
+
 	// カーソルが指定されている場合
 	if (ps.cursor) {
 		query._id = {
 			$lt: ps.cursor
 		};
+	// v11互換パラメーター
+	} else if (ps.sinceId) {
+		sort._id = 1;
+		query._id = {
+			$gt: ps.sinceId
+		};
+		ps.v11compatible = true;
+	} else if (ps.untilId) {
+		query._id = {
+			$lt: ps.untilId
+		};
+		ps.v11compatible = true;
 	}
 
 	// Get followers
@@ -142,7 +187,7 @@ export default define(meta, async (ps, me) => {
 	}, {
 		$sort: { _id: -1 }
 	}, {
-		$limit: ps.limit + 1,
+		$limit: ps.limit! + (ps.v11compatible ? 0 : 1)
 	}, {
 		// join User
 		$lookup: {
@@ -155,16 +200,33 @@ export default define(meta, async (ps, me) => {
 		$unwind: '$_user'
 	}]) as (IFollowing & { _user: IUser })[];
 
-	// 「次のページ」があるかどうか
-	const inStock = following.length === ps.limit + 1;
-	if (inStock) {
-		following.pop();
+	if (!ps.v11compatible) { // V10Following
+		// 「次のページ」があるかどうか
+		const inStock = following.length === ps.limit! + 1;
+		if (inStock) {
+			following.pop();
+		}
+
+		const users = await Promise.all(following.map(f => pack(f._user, me, { detail: true })));
+
+		return {
+			users: users,
+			next: inStock ? following[following.length - 1]._id : null,
+		};
+	} else {
+		const packFollower = async (
+			x: IFollowing & { _user: IUser },
+			me?: ILocalUser | null | undefined,
+		): Promise<PackedFollower> => {
+			return {
+				id: toOidString(x._id),
+				createdAt: toISODateOrNull(x.createdAt),
+				followeeId: toOidString(x.followeeId),
+				followerId: toOidString(x.followerId),
+				follower: await packUser(x._user, me, { detail: true }),
+			};
+		}
+
+		return await Promise.all(following.map(x => packFollower));
 	}
-
-	const users = await Promise.all(following.map(f => pack(f._user, me, { detail: true })));
-
-	return {
-		users: users,
-		next: inStock ? following[following.length - 1]._id : null,
-	};
 });

--- a/src/server/api/endpoints/users/followers.ts
+++ b/src/server/api/endpoints/users/followers.ts
@@ -56,7 +56,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このIDより未来のレコードを取得します。またEntiryがv11互換に変わります。またソート順が逆になります。'
+				'ja-JP': '[v11-互換] 指定すると、このIDより未来のレコードを取得します。またソート順が逆になります。'
 			}
 		},
 
@@ -64,7 +64,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このIDより過去のレコードを取得します。またEntiryがv11互換に変わります。'
+				'ja-JP': '[v11-互換] 指定すると、このIDより過去のレコードを取得します。'
 			}
 		},
 
@@ -173,12 +173,10 @@ export default define(meta, async (ps, me) => {
 		query._id = {
 			$gt: ps.sinceId
 		};
-		ps.v11compatible = true;
 	} else if (ps.untilId) {
 		query._id = {
 			$lt: ps.untilId
 		};
-		ps.v11compatible = true;
 	}
 
 	// Get followers

--- a/src/server/api/endpoints/users/followers.ts
+++ b/src/server/api/endpoints/users/followers.ts
@@ -56,7 +56,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このIDより未来のレコードを取得します。またソート順が逆になります。'
+				'ja-JP': '指定すると、このIDより未来のレコードを取得します。またソート順が逆になります。'
 			}
 		},
 
@@ -64,7 +64,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このIDより過去のレコードを取得します。'
+				'ja-JP': '指定すると、このIDより過去のレコードを取得します。'
 			}
 		},
 
@@ -72,7 +72,7 @@ export const meta = {
 			validator: $.optional.bool,
 			default: false,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、Entiryがv11互換に変わります。'
+				'ja-JP': '指定すると、Entiryがv11互換に変わります。'
 			}
 		},
 

--- a/src/server/api/endpoints/users/following.ts
+++ b/src/server/api/endpoints/users/following.ts
@@ -253,7 +253,7 @@ export default define(meta, async (ps, me) => {
 				createdAt: toISODateOrNull(x.createdAt),
 				followeeId: toOidString(x.followeeId),
 				followerId: toOidString(x.followerId),
-				followee: await packUser(x._user, me, { detail: true }),
+				followee: (await packUser(x._user, me, { detail: true }))!,	// TODO: User.packの型をなおす
 			};
 		}
 

--- a/src/server/api/endpoints/users/following.ts
+++ b/src/server/api/endpoints/users/following.ts
@@ -1,6 +1,6 @@
 import $ from 'cafy';
 import ID, { transform } from '../../../../misc/cafy-id';
-import User, { IUser } from '../../../../models/user';
+import User, { IUser, ILocalUser, pack as packUser } from '../../../../models/user';
 import Following, { IFollowing } from '../../../../models/following';
 import { pack } from '../../../../models/user';
 import { getFriendIds } from '../../common/get-friends';
@@ -8,6 +8,8 @@ import define from '../../define';
 import { ApiError } from '../../error';
 import { getFollowerIds } from '../../common/get-followers';
 import { canShowFollows } from '../../common/can-show-follows';
+import { V10Followees, PackedFollowee } from '../../../../models/packed-schemas';
+import { toOidString, toISODateOrNull } from '../../../../misc/pack-utils';
 
 export const meta = {
 	desc: {
@@ -46,6 +48,33 @@ export const meta = {
 			validator: $.optional.type(ID),
 			default: null as any,
 			transform: transform,
+			desc: {
+				'ja-JP': '指定すると、このRelationIDより過去のレコードを取得します。'
+			}
+		},
+
+		sinceId: {
+			validator: $.optional.type(ID),
+			transform: transform,
+			desc: {
+				'ja-JP': '[v11-互換] 指定すると、このRelationIDより未来のレコードを取得します。またEntiryがv11互換に変わります。またソート順が逆になります。'
+			}
+		},
+
+		untilId: {
+			validator: $.optional.type(ID),
+			transform: transform,
+			desc: {
+				'ja-JP': '[v11-互換] 指定すると、このRelationIDより過去のレコードを取得します。またEntiryがv11互換に変わります。'
+			}
+		},
+
+		v11compatible: {
+			validator: $.optional.bool,
+			default: false,
+			desc: {
+				'ja-JP': '[v11-互換] 指定すると、Entiryがv11互換に変わります。'
+			}
 		},
 
 		iknow: {
@@ -136,11 +165,27 @@ export default define(meta, async (ps, me) => {
 		};
 	}
 
+	const sort = {
+		_id: -1
+	};
+
 	// カーソルが指定されている場合
 	if (ps.cursor) {
 		query._id = {
 			$lt: ps.cursor
 		};
+	// v11互換パラメーター
+	} else if (ps.sinceId) {
+		sort._id = 1;
+		query._id = {
+			$gt: ps.sinceId
+		};
+		ps.v11compatible = true;
+	} else if (ps.untilId) {
+		query._id = {
+			$lt: ps.untilId
+		};
+		ps.v11compatible = true;
 	}
 
 	let following: (IFollowing & { _user: IUser })[];
@@ -151,7 +196,7 @@ export default define(meta, async (ps, me) => {
 		}, {
 			$sort: { _id: -1 }
 		}, {
-			$limit: ps.limit + 1,
+			$limit: ps.limit! + (ps.v11compatible ? 0 : 1)
 		}, {
 			// join User
 			$lookup: {
@@ -183,20 +228,35 @@ export default define(meta, async (ps, me) => {
 		}, {
 			$sort: { _id: -1 }
 		}, {
-			$limit: ps.limit + 1,
+			$limit: ps.limit! + (ps.v11compatible ? 0 : 1)
 		}]) as (IFollowing & { _user: IUser })[];
 	}
 
-	// 「次のページ」があるかどうか
-	const inStock = following.length === ps.limit + 1;
-	if (inStock) {
-		following.pop();
+	if (!ps.v11compatible) {	// V10Following
+		// 「次のページ」があるかどうか
+		const inStock = following.length === ps.limit! + 1;
+		if (inStock) {
+			following.pop();
+		}
+
+		return {
+			users: await Promise.all(following.map(f => pack(f._user, me, { detail: true }))),
+			next: inStock ? toOidString(following[following.length - 1]._id) : null,
+		} as V10Followees;
+	} else {	// v11
+		const packFollowee = async (
+			x: IFollowing & { _user: IUser },
+			me?: ILocalUser | null | undefined,
+		): Promise<PackedFollowee> => {
+			return {
+				id: toOidString(x._id),
+				createdAt: toISODateOrNull(x.createdAt),
+				followeeId: toOidString(x.followeeId),
+				followerId: toOidString(x.followerId),
+				followee: await packUser(x._user, me, { detail: true }),
+			};
+		}
+
+		return await Promise.all(following.map(x => packFollowee));
 	}
-
-	const users = await Promise.all(following.map(f => pack(f._user, me, { detail: true })));
-
-	return {
-		users: users,
-		next: inStock ? following[following.length - 1]._id : null,
-	};
 });

--- a/src/server/api/endpoints/users/following.ts
+++ b/src/server/api/endpoints/users/following.ts
@@ -57,7 +57,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このRelationIDより未来のレコードを取得します。またソート順が逆になります。'
+				'ja-JP': '指定すると、このRelationIDより未来のレコードを取得します。またソート順が逆になります。'
 			}
 		},
 
@@ -65,7 +65,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このRelationIDより過去のレコードを取得します。'
+				'ja-JP': '指定すると、このRelationIDより過去のレコードを取得します。'
 			}
 		},
 
@@ -73,7 +73,7 @@ export const meta = {
 			validator: $.optional.bool,
 			default: false,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、Entiryがv11互換に変わります。'
+				'ja-JP': '指定すると、Entiryがv11互換に変わります。'
 			}
 		},
 

--- a/src/server/api/endpoints/users/following.ts
+++ b/src/server/api/endpoints/users/following.ts
@@ -57,7 +57,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このRelationIDより未来のレコードを取得します。またEntiryがv11互換に変わります。またソート順が逆になります。'
+				'ja-JP': '[v11-互換] 指定すると、このRelationIDより未来のレコードを取得します。またソート順が逆になります。'
 			}
 		},
 
@@ -65,7 +65,7 @@ export const meta = {
 			validator: $.optional.type(ID),
 			transform: transform,
 			desc: {
-				'ja-JP': '[v11-互換] 指定すると、このRelationIDより過去のレコードを取得します。またEntiryがv11互換に変わります。'
+				'ja-JP': '[v11-互換] 指定すると、このRelationIDより過去のレコードを取得します。'
 			}
 		},
 
@@ -180,12 +180,10 @@ export default define(meta, async (ps, me) => {
 		query._id = {
 			$gt: ps.sinceId
 		};
-		ps.v11compatible = true;
 	} else if (ps.untilId) {
 		query._id = {
 			$lt: ps.untilId
 		};
-		ps.v11compatible = true;
 	}
 
 	let following: (IFollowing & { _user: IUser })[];

--- a/src/server/api/endpoints/users/following.ts
+++ b/src/server/api/endpoints/users/following.ts
@@ -253,7 +253,7 @@ export default define(meta, async (ps, me) => {
 				createdAt: toISODateOrNull(x.createdAt),
 				followeeId: toOidString(x.followeeId),
 				followerId: toOidString(x.followerId),
-				followee: (await packUser(x._user, me, { detail: true }))!,	// TODO: User.packの型をなおす
+				followee: await packUser(x._user, me, { detail: true }),
 			};
 		}
 

--- a/src/server/api/endpoints/users/following.ts
+++ b/src/server/api/endpoints/users/following.ts
@@ -255,6 +255,6 @@ export default define(meta, async (ps, me) => {
 			};
 		}
 
-		return await Promise.all(following.map(x => packFollowee));
+		return await Promise.all(following.map(x => packFollowee(x)));
 	}
 });


### PR DESCRIPTION
## Summary
API `users/followers`, `users/following` で、v11-にある `sinceId`, `untilId` が使えるように
`v11compatible: true` でv11以降の形式で応答を返すように