### PR TITLE
Basic MFM Parser

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -1,4 +1,4 @@
-import { parseFull } from '../../../../mfm/parse';
+import { parseBasic } from '../../../../mfm/parse';
 import { sum, unique } from '../../../../prelude/array';
 import { shouldMuteNote } from './should-mute-note';
 import MkNoteMenu from '../views/components/note-menu.vue';
@@ -87,8 +87,7 @@ export default (opts: Opts = {}) => ({
 
 		urls(): string[] {
 			if (this.appearNote.text) {
-				const ast = parseFull(this.appearNote.text);
-				// TODO: 再帰的にURL要素がないか調べる
+				const ast = parseBasic(this.appearNote.text);
 				const urls = unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))
 					.map(t => t.node.props.url));

--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -1,4 +1,4 @@
-import { parse } from '../../../../mfm/parse';
+import { parseFull } from '../../../../mfm/parse';
 import { sum, unique } from '../../../../prelude/array';
 import { shouldMuteNote } from './should-mute-note';
 import MkNoteMenu from '../views/components/note-menu.vue';
@@ -87,7 +87,7 @@ export default (opts: Opts = {}) => ({
 
 		urls(): string[] {
 			if (this.appearNote.text) {
-				const ast = parse(this.appearNote.text);
+				const ast = parseFull(this.appearNote.text);
 				// TODO: 再帰的にURL要素がないか調べる
 				const urls = unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))

--- a/src/client/app/common/scripts/post-form.ts
+++ b/src/client/app/common/scripts/post-form.ts
@@ -2,7 +2,7 @@ import insertTextAtCursor from 'insert-text-at-cursor';
 import { length } from 'stringz';
 import MkVisibilityChooser from '../views/components/visibility-chooser.vue';
 import getFace from './get-face';
-import { parse } from '../../../../mfm/parse';
+import { parseFull } from '../../../../mfm/parse';
 import i18n from '../../i18n';
 import { erase, unique, concat } from '../../../../prelude/array';
 import { faFish, faShareSquare } from '@fortawesome/free-solid-svg-icons';
@@ -446,7 +446,7 @@ export default (opts) => ({
 			});
 
 			if (this.text && this.text != '') {
-				const hashtags = parse(this.text).filter(x => x.node.type === 'hashtag').map(x => x.node.props.hashtag);
+				const hashtags = parseFull(this.text).filter(x => x.node.type === 'hashtag').map(x => x.node.props.hashtag);
 				const history = JSON.parse(localStorage.getItem('hashtags') || '[]') as string[];
 				localStorage.setItem('hashtags', JSON.stringify(unique(hashtags.concat(history))));
 			}

--- a/src/client/app/common/scripts/post-form.ts
+++ b/src/client/app/common/scripts/post-form.ts
@@ -2,7 +2,7 @@ import insertTextAtCursor from 'insert-text-at-cursor';
 import { length } from 'stringz';
 import MkVisibilityChooser from '../views/components/visibility-chooser.vue';
 import getFace from './get-face';
-import { parseFull } from '../../../../mfm/parse';
+import { parseBasic } from '../../../../mfm/parse';
 import i18n from '../../i18n';
 import { erase, unique, concat } from '../../../../prelude/array';
 import { faFish, faShareSquare } from '@fortawesome/free-solid-svg-icons';
@@ -446,7 +446,7 @@ export default (opts) => ({
 			});
 
 			if (this.text && this.text != '') {
-				const hashtags = parseFull(this.text).filter(x => x.node.type === 'hashtag').map(x => x.node.props.hashtag);
+				const hashtags = parseBasic(this.text).filter(x => x.node.type === 'hashtag').map(x => x.node.props.hashtag);
 				const history = JSON.parse(localStorage.getItem('hashtags') || '[]') as string[];
 				localStorage.setItem('hashtags', JSON.stringify(unique(hashtags.concat(history))));
 			}

--- a/src/client/app/common/views/components/messaging-room.message.vue
+++ b/src/client/app/common/views/components/messaging-room.message.vue
@@ -34,7 +34,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../i18n';
-import { parse } from '../../../../../mfm/parse';
+import { parseFull } from '../../../../../mfm/parse';
 import { unique } from '../../../../../prelude/array';
 
 export default Vue.extend({
@@ -50,7 +50,7 @@ export default Vue.extend({
 		},
 		urls(): string[] {
 			if (this.message.text) {
-				const ast = parse(this.message.text);
+				const ast = parseFull(this.message.text);
 				return unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))
 					.map(t => t.node.props.url));

--- a/src/client/app/common/views/components/messaging-room.message.vue
+++ b/src/client/app/common/views/components/messaging-room.message.vue
@@ -34,7 +34,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../i18n';
-import { parseFull } from '../../../../../mfm/parse';
+import { parseBasic } from '../../../../../mfm/parse';
 import { unique } from '../../../../../prelude/array';
 
 export default Vue.extend({
@@ -50,7 +50,7 @@ export default Vue.extend({
 		},
 		urls(): string[] {
 			if (this.message.text) {
-				const ast = parseFull(this.message.text);
+				const ast = parseBasic(this.message.text);
 				return unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))
 					.map(t => t.node.props.url));

--- a/src/client/app/common/views/components/mfm.ts
+++ b/src/client/app/common/views/components/mfm.ts
@@ -1,7 +1,7 @@
 import Vue, { VNode } from 'vue';
 import { length } from 'stringz';
 import { MfmForest, urlRegex } from '../../../../../mfm/prelude';
-import { parseFull, parsePlain, parsePlainX } from '../../../../../mfm/parse';
+import { parseFull, parsePlain, parsePlainX, parseBasic } from '../../../../../mfm/parse';
 import MkUrl from './url.vue';
 import MkMention from './mention.vue';
 import { concat, sum } from '../../../../../prelude/array';
@@ -22,11 +22,17 @@ export default Vue.component('misskey-flavored-markdown', {
 			type: String,
 			required: true
 		},
+		// plain扱い (絵文字のみ)
 		plain: {
 			type: Boolean,
 			default: false
 		},
+		// plain扱いだけどインライン装飾も許可
 		extra: {
+			type: Boolean,
+			default: false
+		},
+		basic: {
 			type: Boolean,
 			default: false
 		},
@@ -54,7 +60,7 @@ export default Vue.component('misskey-flavored-markdown', {
 	render(createElement) {
 		if (this.text == null || this.text == '') return;
 
-		const ast = (this.plain ? this.extra ? parsePlainX : parsePlain : parseFull)(this.text);
+		const ast = (this.basic ? parseBasic : this.plain ? this.extra ? parsePlainX : parsePlain : parseFull)(this.text);
 
 		let bigCount = 0;
 		let motionCount = 0;

--- a/src/client/app/common/views/components/mfm.ts
+++ b/src/client/app/common/views/components/mfm.ts
@@ -1,7 +1,7 @@
 import Vue, { VNode } from 'vue';
 import { length } from 'stringz';
 import { MfmForest } from '../../../../../mfm/prelude';
-import { parse, parsePlain, parsePlainX } from '../../../../../mfm/parse';
+import { parseFull, parsePlain, parsePlainX } from '../../../../../mfm/parse';
 import MkUrl from './url.vue';
 import MkMention from './mention.vue';
 import { concat, sum } from '../../../../../prelude/array';
@@ -54,7 +54,7 @@ export default Vue.component('misskey-flavored-markdown', {
 	render(createElement) {
 		if (this.text == null || this.text == '') return;
 
-		const ast = (this.plain ? this.extra ? parsePlainX : parsePlain : parse)(this.text);
+		const ast = (this.plain ? this.extra ? parsePlainX : parsePlain : parseFull)(this.text);
 
 		let bigCount = 0;
 		let motionCount = 0;

--- a/src/client/app/common/views/components/page/page.text.vue
+++ b/src/client/app/common/views/components/page/page.text.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { parse } from '../../../../../../mfm/parse';
+import { parseFull } from '../../../../../../mfm/parse';
 import { unique } from '../../../../../../prelude/array';
 
 export default Vue.extend({
@@ -30,7 +30,7 @@ export default Vue.extend({
 	computed: {
 		urls(): string[] {
 			if (this.text) {
-				const ast = parse(this.text);
+				const ast = parseFull(this.text);
 				// TODO: 再帰的にURL要素がないか調べる
 				return unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))

--- a/src/client/app/common/views/components/page/page.text.vue
+++ b/src/client/app/common/views/components/page/page.text.vue
@@ -8,7 +8,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { parseFull } from '../../../../../../mfm/parse';
+import { parseBasic } from '../../../../../../mfm/parse';
 import { unique } from '../../../../../../prelude/array';
 
 export default Vue.extend({
@@ -30,8 +30,7 @@ export default Vue.extend({
 	computed: {
 		urls(): string[] {
 			if (this.text) {
-				const ast = parseFull(this.text);
-				// TODO: 再帰的にURL要素がないか調べる
+				const ast = parseBasic(this.text);
 				return unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))
 					.map(t => t.node.props.url));

--- a/src/client/app/common/views/components/welcome-timeline.vue
+++ b/src/client/app/common/views/components/welcome-timeline.vue
@@ -16,7 +16,7 @@
 					</div>
 				</header>
 				<div class="text">
-					<mfm v-if="note.text" :text="note.cw != null ? note.cw : note.text" :author="note.user" :custom-emojis="note.emojis"/>
+					<mfm v-if="note.text" :text="note.cw != null ? note.cw : note.text" :author="note.user" :custom-emojis="note.emojis" :basic="!!note.notHaveDecorationMfm"/>
 				</div>
 				<mk-reactions-viewer class="reactions" :note="note"/>
 			</div>

--- a/src/client/app/common/views/pages/mfm-cheat-sheet.vue
+++ b/src/client/app/common/views/pages/mfm-cheat-sheet.vue
@@ -73,56 +73,56 @@
 	</section>
 
 	<section>
-		<header>引用</header>
+		<header>引用 (ブロック要素)</header>
 		<p>引用を示すことができます。</p>
 		<p><mfm :text="preview_quote" :key="preview_quote"/></p>
 		<ui-textarea :slim="true" class="text" v-model="preview_quote"></ui-textarea>
 	</section>
 
 	<section>
-		<header>中央寄せ</header>
+		<header>中央寄せ (ブロック要素)<</header>
 		<p>中央寄せで表示することができます。</p>
 		<p><mfm :text="preview_center" :key="preview_center"/></p>
 		<ui-textarea :slim="true" class="text" v-model="preview_center"></ui-textarea>
 	</section>
 
 	<section>
-		<header>コード (インライン)</header>
+		<header>インラインコード</header>
 		<p>ソースコードなどをインラインでシンタックスハイライトします。</p>
 		<p><mfm :text="preview_inlineCode" :key="preview_inlineCode"/></p>
 		<ui-textarea :slim="true" class="text" v-model="preview_inlineCode"></ui-textarea>
 	</section>
 
 	<section>
-		<header>コード (ブロック)</header>
+		<header>コードブロック (ブロック要素)</header>
 		<p>ソースコードなどをブロックでシンタックスハイライトします。言語指定も出来ます。</p>
 		<p><mfm :text="preview_blockCode" :key="preview_blockCode"/></p>
 		<ui-textarea :slim="false" class="text" v-model="preview_blockCode"></ui-textarea>
 	</section>
 
 	<section>
-		<header>数式 (インライン)</header>
+		<header>インライン数式</header>
 		<p>数式 (KaTeX)をインラインで表示します。</p>
 		<p><mfm :text="preview_inlineMath" :key="preview_inlineMath"/></p>
 		<ui-textarea :slim="true" class="text" v-model="preview_inlineMath"></ui-textarea>
 	</section>
 
 	<section>
-		<header>数式 (ブロック)</header>
+		<header>ブロック数式 (ブロック要素)</header>
 		<p>数式 (KaTeX)をブロックで表示します。</p>
 		<p><mfm :text="preview_blockMath" :key="preview_blockMath"/></p>
 		<ui-textarea :slim="false" class="text" v-model="preview_blockMath"></ui-textarea>
 	</section>
 
 	<section>
-		<header>検索</header>
+		<header>検索 (ブロック要素)</header>
 		<p>入力済み検索ボックスを表示させることができます。</p>
 		<p><mfm :text="preview_search" :key="preview_search"/></p>
 		<ui-textarea :slim="true" class="text" v-model="preview_search"></ui-textarea>
 	</section>
 
 	<section>
-		<header>タイトル</header>
+		<header>タイトル (ブロック要素)</header>
 		<p>タイトルのようになります</p>
 		<p><mfm :text="preview_title" :key="preview_title"/></p>
 		<ui-textarea :slim="true" class="text" v-model="preview_title"></ui-textarea>
@@ -164,7 +164,7 @@
 	</section>
 
 	<section>
-		<header>マーキー</header>
+		<header>マーキー (ブロック要素)</header>
 		<p><mfm :text="preview_marquee" :key="preview_marquee"/></p>
 		<ui-textarea :slim="false" class="text" v-model="preview_marquee"></ui-textarea>
 	</section>

--- a/src/client/app/desktop/views/components/note-detail.vue
+++ b/src/client/app/desktop/views/components/note-detail.vue
@@ -28,14 +28,14 @@
 		</header>
 		<div class="body">
 			<p v-if="appearNote.cw != null" class="cw">
-				<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" />
+				<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" :basic="!!appearNote.notHaveDecorationMfm" />
 				<mk-cw-button v-model="showContent" :note="appearNote"/>
 			</p>
 			<div class="content" v-show="appearNote.cw == null || showContent">
 				<div class="text">
 					<span v-if="appearNote.isHidden" style="opacity: 0.5">{{ $t('private') }}</span>
 					<span v-if="appearNote.deletedAt" style="opacity: 0.5">{{ $t('deleted') }}</span>
-					<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" />
+					<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" :basic="!!appearNote.notHaveDecorationMfm" />
 				</div>
 				<div class="files" v-if="appearNote.files.length > 0">
 					<mk-media-list :media-list="appearNote.files" :hide="!$store.state.device.alwaysShowNsfw && appearNote.cw == null"/>

--- a/src/client/app/desktop/views/components/note-preview.vue
+++ b/src/client/app/desktop/views/components/note-preview.vue
@@ -5,7 +5,7 @@
 		<mk-note-header class="header" :note="note" :mini="true"/>
 		<div class="body">
 			<p v-if="note.cw != null" class="cw">
-				<mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" />
+				<mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" :basic="!!note.notHaveDecorationMfm" />
 				<mk-cw-button v-model="showContent" :note="note"/>
 			</p>
 			<div class="content" v-show="note.cw == null || showContent">

--- a/src/client/app/desktop/views/components/note.sub.vue
+++ b/src/client/app/desktop/views/components/note.sub.vue
@@ -5,7 +5,7 @@
 		<mk-note-header class="header" :note="note"/>
 		<div class="body">
 			<p v-if="note.cw != null" class="cw">
-				<mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" />
+				<mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" :basic="!!note.notHaveDecorationMfm" />
 				<mk-cw-button v-model="showContent" :note="note"/>
 			</p>
 			<div class="content" v-show="note.cw == null || showContent">

--- a/src/client/app/desktop/views/components/note.vue
+++ b/src/client/app/desktop/views/components/note.vue
@@ -40,14 +40,14 @@
 			<x-instance-info v-if="appearNote.user.instance && !$store.state.device.disableShowingInstanceInfo" :instance="appearNote.user.instance" />
 			<div class="body" v-if="appearNote.deletedAt == null">
 				<p v-if="appearNote.cw != null" class="cw">
-					<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" />
+					<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" :basic="!!appearNote.notHaveDecorationMfm" />
 					<mk-cw-button v-model="showContent" :note="appearNote"/>
 				</p>
 				<div class="content" v-show="appearNote.cw == null || showContent">
 					<div class="text" :class="{ scroll : !detail }">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">{{ $t('private') }}</span>
 						<a class="reply" v-if="appearNote.reply"><fa icon="reply"/></a>
-						<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis"
+						<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" :basic="!!appearNote.notHaveDecorationMfm"
 							:style="{ 'font-size': appearNote.text && appearNote.text.length > 500 ? '11px' : 'inherit' }"/>
 					</div>
 					<div class="files" v-if="appearNote.files.length > 0">

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -79,7 +79,7 @@ import XVisibilityIcon from '../../../common/views/components/visibility-icon.vu
 import form from '../../../common/scripts/post-form';
 import { toASCII } from 'punycode';
 import extractMentions from '../../../../../misc/extract-mentions';
-import { parseFull } from '../../../../../mfm/parse';
+import { parseBasic } from '../../../../../mfm/parse';
 import { host } from '../../../config';
 
 export default Vue.extend({
@@ -129,7 +129,7 @@ export default Vue.extend({
 		}
 
 		if (this.reply && this.reply.text != null) {
-			const ast = parseFull(this.reply.text);
+			const ast = parseBasic(this.reply.text);
 
 			for (const x of extractMentions(ast)) {
 				const mention = x.host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}`;

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -79,7 +79,7 @@ import XVisibilityIcon from '../../../common/views/components/visibility-icon.vu
 import form from '../../../common/scripts/post-form';
 import { toASCII } from 'punycode';
 import extractMentions from '../../../../../misc/extract-mentions';
-import { parse } from '../../../../../mfm/parse';
+import { parseFull } from '../../../../../mfm/parse';
 import { host } from '../../../config';
 
 export default Vue.extend({
@@ -129,7 +129,7 @@ export default Vue.extend({
 		}
 
 		if (this.reply && this.reply.text != null) {
-			const ast = parse(this.reply.text);
+			const ast = parseFull(this.reply.text);
 
 			for (const x of extractMentions(ast)) {
 				const mention = x.host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}`;

--- a/src/client/app/desktop/views/components/sub-note-content.vue
+++ b/src/client/app/desktop/views/components/sub-note-content.vue
@@ -4,7 +4,7 @@
 		<span v-if="note.isHidden" style="opacity: 0.5">{{ $t('private') }}</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">{{ $t('deleted') }}</span>
 		<a class="reply" v-if="note.replyId"><fa icon="reply"/></a>
-		<mfm v-if="note.text" :text="note.text" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis"/>
+		<mfm v-if="note.text" :text="note.text" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" :basic="!!note.notHaveDecorationMfm"/>
 		<router-link class="rp" v-if="note.renoteId" :to="`/notes/${note.renoteId}`">RN: ...</router-link>
 	</div>
 	<details v-if="note.files.length > 0" :open="note.cw != null">

--- a/src/client/app/mobile/views/components/note-detail.vue
+++ b/src/client/app/mobile/views/components/note-detail.vue
@@ -27,14 +27,14 @@
 		</header>
 		<div class="body">
 			<p v-if="appearNote.cw != null" class="cw">
-				<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" />
+				<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis"  :basic="!!appearNote.notHaveDecorationMfm"/>
 				<mk-cw-button v-model="showContent" :note="appearNote"/>
 			</p>
 			<div class="content" v-show="appearNote.cw == null || showContent">
 				<div class="text">
 					<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ $t('private') }})</span>
 					<span v-if="appearNote.deletedAt" style="opacity: 0.5">({{ $t('deleted') }})</span>
-					<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis"/>
+					<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" :basic="!!appearNote.notHaveDecorationMfm"/>
 				</div>
 				<div class="files" v-if="appearNote.files.length > 0">
 					<mk-media-list :media-list="appearNote.files" :hide="!$store.state.device.alwaysShowNsfw && appearNote.cw == null"/>

--- a/src/client/app/mobile/views/components/note.sub.vue
+++ b/src/client/app/mobile/views/components/note.sub.vue
@@ -5,7 +5,7 @@
 		<mk-note-header class="header" :note="note" :mini="true"/>
 		<div class="body">
 			<p v-if="note.cw != null" class="cw">
-				<mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" />
+				<mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis"  :basic="!!note.notHaveDecorationMfm"/>
 				<mk-cw-button v-model="showContent" :note="note"/>
 			</p>
 			<div class="content" v-show="note.cw == null || showContent">

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -41,14 +41,14 @@
 			<x-instance-info v-if="appearNote.user.instance && !$store.state.device.disableShowingInstanceInfo" :instance="appearNote.user.instance" />
 			<div class="body" v-if="appearNote.deletedAt == null">
 				<p v-if="appearNote.cw != null" class="cw">
-				<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" />
+				<mfm v-if="appearNote.cw != ''" class="text" :text="appearNote.cw" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis"  :basic="!!appearNote.notHaveDecorationMfm"/>
 					<mk-cw-button v-model="showContent" :note="appearNote"/>
 				</p>
 				<div class="content" v-show="appearNote.cw == null || showContent">
 					<div class="text">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ $t('private') }})</span>
 						<a class="reply" v-if="appearNote.reply"><fa icon="reply"/></a>
-						<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis"/>
+						<mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$store.state.i" :custom-emojis="appearNote.emojis" :basic="!!appearNote.notHaveDecorationMfm"/>
 					</div>
 					<div class="files" v-if="appearNote.files.length > 0">
 						<mk-media-list :media-list="appearNote.files" :hide="!$store.state.device.alwaysShowNsfw && appearNote.cw == null"/>

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -70,7 +70,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../i18n';
-import { parse } from '../../../../../mfm/parse';
+import { parseFull } from '../../../../../mfm/parse';
 import { host } from '../../../config';
 import { toASCII } from 'punycode';
 import extractMentions from '../../../../../misc/extract-mentions';
@@ -142,7 +142,7 @@ export default Vue.extend({
 		}
 
 		if (this.reply && this.reply.text != null) {
-			const ast = parse(this.reply.text);
+			const ast = parseFull(this.reply.text);
 
 			for (const x of extractMentions(ast)) {
 				const mention = x.host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}`;

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -70,7 +70,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../i18n';
-import { parseFull } from '../../../../../mfm/parse';
+import { parseBasic } from '../../../../../mfm/parse';
 import { host } from '../../../config';
 import { toASCII } from 'punycode';
 import extractMentions from '../../../../../misc/extract-mentions';
@@ -142,7 +142,7 @@ export default Vue.extend({
 		}
 
 		if (this.reply && this.reply.text != null) {
-			const ast = parseFull(this.reply.text);
+			const ast = parseBasic(this.reply.text);
 
 			for (const x of extractMentions(ast)) {
 				const mention = x.host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}`;

--- a/src/client/app/mobile/views/components/sub-note-content.vue
+++ b/src/client/app/mobile/views/components/sub-note-content.vue
@@ -4,7 +4,7 @@
 		<span v-if="note.isHidden" style="opacity: 0.5">({{ $t('private') }})</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">({{ $t('deleted') }})</span>
 		<a class="reply" v-if="note.replyId"><fa icon="reply"/></a>
-		<mfm v-if="note.text" :text="note.text" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis"/>
+		<mfm v-if="note.text" :text="note.text" :author="note.user" :i="$store.state.i" :custom-emojis="note.emojis" :basic="!!note.notHaveDecorationMfm"/>
 		<router-link class="rp" v-if="note.renoteId" :to="`/notes/${note.renoteId}`">RN: ...</router-link>
 	</div>
 	<details v-if="note.files.length > 0" :open="note.cw != null">

--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -23,7 +23,7 @@ export const mfmLanguage = P.createLanguage({
 	root: r => P.alt(r.block, r.inline).atLeast(1),
 	plain: r => P.alt(r.emoji, r.text).atLeast(1),
 	plainX: r => P.alt(r.inline).atLeast(1),
-	basic: r => P.alt(r.inlineBasic).atLeast(1),
+	basic: r => P.alt(r.blockBasic, r.inlineBasic).atLeast(1),
 	block: r => P.alt(
 		r.title,
 		r.quote,
@@ -57,13 +57,17 @@ export const mfmLanguage = P.createLanguage({
 		r.fn,
 		r.text
 	),
+	blockBasic: r => P.alt(
+		r.blockCode
+	),
 	inlineBasic: r => P.alt(
 		r.mention,
 		r.hashtag,
 		r.url,
 		r.link,
 		r.emoji,
-		r.text
+		r.text,
+		r.inlineCode,
 	),
 	startOfLine: () => P((input, i) => {
 		if (i == 0 || input[i] == '\n' || input[i - 1] == '\n') {

--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -264,7 +264,7 @@ export const mfmLanguage = P.createLanguage({
 			P.string('['), ['text', P.regexp(/[^\n\[\]]+/)] as any, P.string(']'),
 			P.string('('), ['url', r.url] as any, P.string(')'),
 		).map((x: any) => {
-			return createTree('link', r.inline.atLeast(1).tryParse(x.text), {
+			return createTree('link', r.text.atLeast(1).tryParse(x.text), {
 				silent: x.silent,
 				url: x.url.node.props.url
 			});

--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -23,6 +23,7 @@ export const mfmLanguage = P.createLanguage({
 	root: r => P.alt(r.block, r.inline).atLeast(1),
 	plain: r => P.alt(r.emoji, r.text).atLeast(1),
 	plainX: r => P.alt(r.inline).atLeast(1),
+	basic: r => P.alt(r.inlineBasic).atLeast(1),
 	block: r => P.alt(
 		r.title,
 		r.quote,
@@ -31,6 +32,38 @@ export const mfmLanguage = P.createLanguage({
 		r.mathBlock,
 		r.center,
 		r.marquee
+	),
+	inline: r => P.alt(
+		r.big,
+		r.bold,
+		r.small,
+		r.italic,
+		r.strike,
+		r.motion,
+		r.spin,
+		r.xspin,
+		r.yspin,
+		r.jump,
+		r.flip,
+		r.vflip,
+		r.rotate,
+		r.inlineCode,
+		r.mathInline,
+		r.mention,
+		r.hashtag,
+		r.url,
+		r.link,
+		r.emoji,
+		r.fn,
+		r.text
+	),
+	inlineBasic: r => P.alt(
+		r.mention,
+		r.hashtag,
+		r.url,
+		r.link,
+		r.emoji,
+		r.text
 	),
 	startOfLine: () => P((input, i) => {
 		if (i == 0 || input[i] == '\n' || input[i - 1] == '\n') {
@@ -78,30 +111,7 @@ export const mfmLanguage = P.createLanguage({
 			});
 		}).map(x => createTree('marquee', r.inline.atLeast(1).tryParse(x.content), { attr: x.attr }));
 	},
-	inline: r => P.alt(
-		r.big,
-		r.bold,
-		r.small,
-		r.italic,
-		r.strike,
-		r.motion,
-		r.spin,
-		r.xspin,
-		r.yspin,
-		r.jump,
-		r.flip,
-		r.vflip,
-		r.rotate,
-		r.inlineCode,
-		r.mathInline,
-		r.mention,
-		r.hashtag,
-		r.url,
-		r.link,
-		r.emoji,
-		r.fn,
-		r.text
-	),
+
 	big: r => P.regexp(/^\*\*\*([\s\S]+?)\*\*\*/, 1).map(x => createTree('big', r.inline.atLeast(1).tryParse(x), {})),
 	bold: r => {
 		const asterisk = P.regexp(/\*\*([\s\S]+?)\*\*/, 1);

--- a/src/mfm/parse.ts
+++ b/src/mfm/parse.ts
@@ -2,7 +2,10 @@ import { mfmLanguage } from './language';
 import { MfmForest } from './prelude';
 import { normalize } from './normalize';
 
-export function parse(source: string): MfmForest | null {
+/**
+ * すべて (インライン＋ブロック)
+ */
+export function parseFull(source: string): MfmForest | null {
 	if (source == null || source == '') {
 		return null;
 	}
@@ -10,6 +13,9 @@ export function parse(source: string): MfmForest | null {
 	return normalize(mfmLanguage.root.tryParse(source));
 }
 
+/**
+ * 絵文字のみ
+ */
 export function parsePlain(source: string): MfmForest | null {
 	if (source == null || source == '') {
 		return null;
@@ -18,6 +24,9 @@ export function parsePlain(source: string): MfmForest | null {
 	return normalize(mfmLanguage.plain.tryParse(source));
 }
 
+/**
+ * インライン要素のみ
+ */
 export function parsePlainX(source: string): MfmForest | null {
 	if (source == null || source == '') {
 		return null;

--- a/src/mfm/parse.ts
+++ b/src/mfm/parse.ts
@@ -34,3 +34,11 @@ export function parsePlainX(source: string): MfmForest | null {
 
 	return normalize(mfmLanguage.plainX.tryParse(source));
 }
+
+export function parseBasic(source: string): MfmForest | null {
+	if (source == null || source == '') {
+		return null;
+	}
+
+	return normalize(mfmLanguage.basic.tryParse(source));
+}

--- a/src/mfm/parse.ts
+++ b/src/mfm/parse.ts
@@ -35,6 +35,9 @@ export function parsePlainX(source: string): MfmForest | null {
 	return normalize(mfmLanguage.plainX.tryParse(source));
 }
 
+/**
+ * メンション, タグ, URL, リンク, コード のみ
+ */
 export function parseBasic(source: string): MfmForest | null {
 	if (source == null || source == '') {
 		return null;

--- a/src/mfm/to-html.ts
+++ b/src/mfm/to-html.ts
@@ -4,7 +4,7 @@ import { INote } from '../models/note';
 import { concat } from '../prelude/array';
 import { MfmForest, MfmTree } from './prelude';
 
-export function toHtml(tokens: MfmForest, mentionedRemoteUsers: INote['mentionedRemoteUsers'] = []) {
+export function toHtml(tokens: MfmForest | null, mentionedRemoteUsers: INote['mentionedRemoteUsers'] = []) {
 	if (tokens == null) {
 		return null;
 	}

--- a/src/misc/extract-mfm-types.ts
+++ b/src/misc/extract-mfm-types.ts
@@ -1,0 +1,7 @@
+import { MfmForest } from '../mfm/prelude';
+import { preorderF } from '../prelude/tree';
+import { unique } from '../prelude/array';
+
+export default function(mfmForest: MfmForest): string[] {
+	return unique(preorderF(mfmForest).map(x => x.type));
+}

--- a/src/misc/mecab.ts
+++ b/src/misc/mecab.ts
@@ -1,4 +1,4 @@
-import { parse as parseMfm } from '../mfm/parse';
+import { parseFull } from '../mfm/parse';
 import toText from '../mfm/toText';
 import toWord from '../mfm/toWord';
 import config from '../config';
@@ -13,14 +13,14 @@ const pipeline = util.promisify(stream.pipeline);
 
 export async function getIndexer(note: Partial<Record<'text' | 'cw', string>>): Promise<string[]> {
 	const source = `${note.text || ''} ${note.cw || ''}`;
-	const text = toText(parseMfm(source)!);
+	const text = toText(parseFull(source)!);
 	const tokens = await me(text);
 	return unique(tokens.filter(token => ['フィラー', '感動詞', '形容詞', '連体詞', '動詞', '副詞', '名詞'].includes(token[1])).map(token => token[0]));
 }
 
 export async function getWordIndexer(note: Partial<Record<'text' | 'cw', string>>): Promise<string[]> {
 	const source = `${note.text || ''} ${note.cw || ''}`;
-	const text = toWord(parseMfm(source)!);
+	const text = toWord(parseFull(source)!);
 	const tokens = await me(text);
 	const words = unique(tokens.filter(token => token[2] === '固有名詞').map(token => token[0]));
 

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -12,7 +12,7 @@ import Emoji from './emoji';
 import { packEmojis } from '../misc/pack-emojis';
 import { dbLogger } from '../db/logger';
 import { decodeReaction, decodeReactionCounts } from '../misc/reaction-lib';
-import { parse } from '../mfm/parse';
+import { parseFull } from '../mfm/parse';
 import { toString } from '../mfm/to-string';
 import { PackedNote } from './packed-schemas';
 import { awaitAll } from '../prelude/await-all';
@@ -435,7 +435,7 @@ export const pack = async (
 	});
 
 	if (packed.user?.isCat && packed.text) {
-		const tokens = packed.text ? parse(packed.text) : [];
+		const tokens = packed.text ? parseFull(packed.text) : [];
 		packed.text = toString(tokens, { doNyaize: true });
 	}
 

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -116,6 +116,8 @@ export type INote = {
 	mecabWords?: string[];
 	trendWords?: string[];
 
+	mfmTypes?: string[];
+
 	// 非正規化
 	_reply?: {
 		userId: mongo.ObjectID;
@@ -383,6 +385,14 @@ export const pack = async (
 		return renote ? `${renote._id}` : null;
 	};
 
+	// tslint:disable-next-line:no-unnecessary-initializer
+	let notHaveDecorationMfm: boolean | undefined = undefined;
+
+	if (db.mfmTypes) {
+		const decorationMfmTypes = db.mfmTypes.filter(x => !['text', 'mention', 'hashtag', 'url', 'link', 'emoji', 'blockCode', 'inlineCode'].includes(x)) || [];
+		notHaveDecorationMfm = decorationMfmTypes.length === 0;
+	}
+
 	const packed: PackedNote = await awaitAll({
 		id: toOidString(db._id),
 		createdAt: toISODateOrNull(db.createdAt),
@@ -412,6 +422,7 @@ export const pack = async (
 		url: db.url || null,
 		appId: toOidStringOrNull(db.appId),
 		app: db.appId ? packApp(db.appId) : null,
+		notHaveDecorationMfm,
 
 		visibleUserIds: db.visibleUserIds?.length > 0 ? db.visibleUserIds.map(toOidString) : [],
 		mentions: db.mentions?.length > 0 ? db.mentions.map(toOidString) : [],

--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -34,6 +34,8 @@ export type ThinPackedNote = {
 
 	visibleUserIds: string[];
 	mentions: string[];
+
+	notHaveDecorationMfm?: boolean;
 }
 
 export type PackedNote = ThinPackedNote & {

--- a/src/remote/activitypub/misc/get-note-html.ts
+++ b/src/remote/activitypub/misc/get-note-html.ts
@@ -1,9 +1,9 @@
 import { INote } from '../../../models/note';
 import { toHtml } from '../../../mfm/to-html';
-import { parse } from '../../../mfm/parse';
+import { parseFull } from '../../../mfm/parse';
 
 export default function(note: INote) {
-	let html = toHtml(parse(note.text), note.mentionedRemoteUsers);
+	let html = toHtml(parseFull(note.text), note.mentionedRemoteUsers);
 	if (html == null) html = '<p>.</p>';
 
 	return html;

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -3,7 +3,7 @@ import renderKey from './key';
 import config from '../../../config';
 import { ILocalUser } from '../../../models/user';
 import { toHtml } from '../../../mfm/to-html';
-import { parse } from '../../../mfm/parse';
+import { parseFull } from '../../../mfm/parse';
 import DriveFile from '../../../models/drive-file';
 import { getEmojis } from './note';
 import renderEmoji from './emoji';
@@ -101,7 +101,7 @@ export default async (user: ILocalUser) => {
 		url: `${config.url}/@${user.username}`,
 		preferredUsername: user.username,
 		name: user.name,
-		summary: toHtml(parse(user.description)),
+		summary: toHtml(parseFull(user.description)),
 		icon: (avatar && avatar.metadata && !avatar.metadata.isSensitive) ? renderImage(avatar) : undefined,
 		image: (banner && banner.metadata && !banner.metadata.isSensitive) ? renderImage(banner) : undefined,
 		tag,

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -7,7 +7,7 @@ import acceptAllFollowRequests from '../../../../services/following/requests/acc
 import { publishToFollowers } from '../../../../services/i/update';
 import define from '../../define';
 import getDriveFileUrl from '../../../../misc/get-drive-file-url';
-import { parseFull, parsePlain } from '../../../../mfm/parse';
+import { parseBasic } from '../../../../mfm/parse';
 import extractEmojis from '../../../../misc/extract-emojis';
 import extractHashtags from '../../../../misc/extract-hashtags';
 import { updateUsertags } from '../../../../services/update-hashtag';
@@ -334,12 +334,12 @@ export default define(meta, async (ps, user, app) => {
 		let tags = [] as string[];
 
 		if (updates.name != null) {
-			const tokens = parsePlain(updates.name);
+			const tokens = parseBasic(updates.name);
 			emojis = emojis.concat(extractEmojis(tokens));
 		}
 
 		if (updates.description != null) {
-			const tokens = parseFull(updates.description);
+			const tokens = parseBasic(updates.description);
 			emojis = emojis.concat(extractEmojis(tokens));
 			tags = extractHashtags(tokens).map(tag => normalizeTag(tag)).slice(0, 64);
 		}

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -7,7 +7,7 @@ import acceptAllFollowRequests from '../../../../services/following/requests/acc
 import { publishToFollowers } from '../../../../services/i/update';
 import define from '../../define';
 import getDriveFileUrl from '../../../../misc/get-drive-file-url';
-import { parse, parsePlain } from '../../../../mfm/parse';
+import { parseFull, parsePlain } from '../../../../mfm/parse';
 import extractEmojis from '../../../../misc/extract-emojis';
 import extractHashtags from '../../../../misc/extract-hashtags';
 import { updateUsertags } from '../../../../services/update-hashtag';
@@ -339,7 +339,7 @@ export default define(meta, async (ps, user, app) => {
 		}
 
 		if (updates.description != null) {
-			const tokens = parse(updates.description);
+			const tokens = parseFull(updates.description);
 			emojis = emojis.concat(extractEmojis(tokens));
 			tags = extractHashtags(tokens).map(tag => normalizeTag(tag)).slice(0, 64);
 		}

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -11,7 +11,7 @@ import DriveFile, { IDriveFile } from '../../models/drive-file';
 import { createNotification } from '../../services/create-notification';
 import NoteWatching from '../../models/note-watching';
 import watch from './watch';
-import { parse } from '../../mfm/parse';
+import { parseFull } from '../../mfm/parse';
 import { IApp } from '../../models/app';
 import resolveUser from '../../remote/resolve-user';
 import Meta from '../../models/meta';
@@ -205,10 +205,10 @@ export default async (user: IUser, data: Option, silent = false) => {
 
 	// Parse MFM if needed
 	if (parseEmojisInToken || !tags || !emojis || !mentionedUsers) {
-		const tokens = data.text ? parse(data.text) : [];
-		const cwTokens = data.cw ? parse(data.cw) : [];
+		const tokens = data.text ? parseFull(data.text) : [];
+		const cwTokens = data.cw ? parseFull(data.cw) : [];
 		const choiceTokens = data.poll && data.poll.choices
-			? concat((data.poll.choices as IChoice[]).map(choice => parse(choice.text)))
+			? concat((data.poll.choices as IChoice[]).map(choice => parseFull(choice.text)))
 			: [];
 
 		const combinedTokens = tokens.concat(cwTokens).concat(choiceTokens);

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -11,7 +11,7 @@ import DriveFile, { IDriveFile } from '../../models/drive-file';
 import { createNotification } from '../../services/create-notification';
 import NoteWatching from '../../models/note-watching';
 import watch from './watch';
-import { parseFull } from '../../mfm/parse';
+import { parseBasic } from '../../mfm/parse';
 import { IApp } from '../../models/app';
 import resolveUser from '../../remote/resolve-user';
 import Meta from '../../models/meta';
@@ -205,10 +205,10 @@ export default async (user: IUser, data: Option, silent = false) => {
 
 	// Parse MFM if needed
 	if (parseEmojisInToken || !tags || !emojis || !mentionedUsers) {
-		const tokens = data.text ? parseFull(data.text) : [];
-		const cwTokens = data.cw ? parseFull(data.cw) : [];
+		const tokens = data.text ? parseBasic(data.text) : [];
+		const cwTokens = data.cw ? parseBasic(data.cw) : [];
 		const choiceTokens = data.poll && data.poll.choices
-			? concat((data.poll.choices as IChoice[]).map(choice => parseFull(choice.text)))
+			? concat((data.poll.choices as IChoice[]).map(choice => parseBasic(choice.text)))
 			: [];
 
 		const combinedTokens = tokens.concat(cwTokens).concat(choiceTokens);

--- a/test/extract-mentions.ts
+++ b/test/extract-mentions.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 
 import extractMentions from '../src/misc/extract-mentions';
-import { parseFull } from '../src/mfm/parse';
+import { parseFull, parseBasic } from '../src/mfm/parse';
 
 describe('Extract mentions', () => {
 	it('simple', () => {
@@ -27,6 +27,48 @@ describe('Extract mentions', () => {
 
 	it('nested', () => {
 		const ast = parseFull('@foo **@bar** @baz')!;
+		const mentions = extractMentions(ast);
+		assert.deepStrictEqual(mentions, [{
+			username: 'foo',
+			acct: '@foo',
+			canonical: '@foo',
+			host: null
+		}, {
+			username: 'bar',
+			acct: '@bar',
+			canonical: '@bar',
+			host: null
+		}, {
+			username: 'baz',
+			acct: '@baz',
+			canonical: '@baz',
+			host: null
+		}]);
+	});
+
+	it('simple basic', () => {
+		const ast = parseBasic('@foo @bar @baz')!;
+		const mentions = extractMentions(ast);
+		assert.deepStrictEqual(mentions, [{
+			username: 'foo',
+			acct: '@foo',
+			canonical: '@foo',
+			host: null
+		}, {
+			username: 'bar',
+			acct: '@bar',
+			canonical: '@bar',
+			host: null
+		}, {
+			username: 'baz',
+			acct: '@baz',
+			canonical: '@baz',
+			host: null
+		}]);
+	});
+
+	it('nested basic', () => {
+		const ast = parseBasic('@foo **@bar** @baz')!;
 		const mentions = extractMentions(ast);
 		assert.deepStrictEqual(mentions, [{
 			username: 'foo',

--- a/test/extract-mentions.ts
+++ b/test/extract-mentions.ts
@@ -1,11 +1,11 @@
 import * as assert from 'assert';
 
 import extractMentions from '../src/misc/extract-mentions';
-import { parse } from '../src/mfm/parse';
+import { parseFull } from '../src/mfm/parse';
 
 describe('Extract mentions', () => {
 	it('simple', () => {
-		const ast = parse('@foo @bar @baz')!;
+		const ast = parseFull('@foo @bar @baz')!;
 		const mentions = extractMentions(ast);
 		assert.deepStrictEqual(mentions, [{
 			username: 'foo',
@@ -26,7 +26,7 @@ describe('Extract mentions', () => {
 	});
 
 	it('nested', () => {
-		const ast = parse('@foo **@bar** @baz')!;
+		const ast = parseFull('@foo **@bar** @baz')!;
 		const mentions = extractMentions(ast);
 		assert.deepStrictEqual(mentions, [{
 			username: 'foo',

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -10,7 +10,7 @@
 
 import * as assert from 'assert';
 
-import { parse, parsePlain } from '../src/mfm/parse';
+import { parseFull, parsePlain } from '../src/mfm/parse';
 import { createTree as tree, createLeaf as leaf, MfmTree } from '../src/mfm/prelude';
 import { removeOrphanedBrackets } from '../src/mfm/language';
 
@@ -150,7 +150,7 @@ describe('removeOrphanedBrackets', () => {
 
 describe('MFM', () => {
 	it('can be analyzed', () => {
-		const tokens = parse('@himawari @hima_sub@namori.net お腹ペコい :cat: #yryr');
+		const tokens = parseFull('@himawari @hima_sub@namori.net お腹ペコい :cat: #yryr');
 		assert.deepStrictEqual(tokens, [
 			leaf('mention', {
 				acct: '@himawari',
@@ -175,7 +175,7 @@ describe('MFM', () => {
 	describe('elements', () => {
 		describe('bold', () => {
 			it('simple', () => {
-				const tokens = parse('**foo**');
+				const tokens = parseFull('**foo**');
 				assert.deepStrictEqual(tokens, [
 					tree('bold', [
 						text('foo')
@@ -184,7 +184,7 @@ describe('MFM', () => {
 			});
 
 			it('with other texts', () => {
-				const tokens = parse('bar**foo**bar');
+				const tokens = parseFull('bar**foo**bar');
 				assert.deepStrictEqual(tokens, [
 					text('bar'),
 					tree('bold', [
@@ -195,7 +195,7 @@ describe('MFM', () => {
 			});
 
 			it('with underscores', () => {
-				const tokens = parse('__foo__');
+				const tokens = parseFull('__foo__');
 				assert.deepStrictEqual(tokens, [
 					tree('bold', [
 						text('foo')
@@ -204,21 +204,21 @@ describe('MFM', () => {
 			});
 
 			it('with underscores (ensure it allows alphabet only)', () => {
-				const tokens = parse('(=^・__________・^=)');
+				const tokens = parseFull('(=^・__________・^=)');
 				assert.deepStrictEqual(tokens, [
 					text('(=^・__________・^=)')
 				]);
 			});
 
 			it('mixed syntax', () => {
-				const tokens = parse('**foo__');
+				const tokens = parseFull('**foo__');
 				assert.deepStrictEqual(tokens, [
 						text('**foo__'),
 				]);
 			});
 
 			it('mixed syntax', () => {
-				const tokens = parse('__foo**');
+				const tokens = parseFull('__foo**');
 				assert.deepStrictEqual(tokens, [
 						text('__foo**'),
 				]);
@@ -226,7 +226,7 @@ describe('MFM', () => {
 		});
 
 		it('big', () => {
-			const tokens = parse('***Strawberry*** Pasta');
+			const tokens = parseFull('***Strawberry*** Pasta');
 			assert.deepStrictEqual(tokens, [
 				tree('big', [
 					text('Strawberry')
@@ -236,7 +236,7 @@ describe('MFM', () => {
 		});
 
 		it('small', () => {
-			const tokens = parse('<small>smaller</small>');
+			const tokens = parseFull('<small>smaller</small>');
 			assert.deepStrictEqual(tokens, [
 				tree('small', [
 					text('smaller')
@@ -245,7 +245,7 @@ describe('MFM', () => {
 		});
 
 		it('flip', () => {
-			const tokens = parse('<flip>foo</flip>');
+			const tokens = parseFull('<flip>foo</flip>');
 			assert.deepStrictEqual(tokens, [
 				tree('flip', [
 					text('foo')
@@ -254,7 +254,7 @@ describe('MFM', () => {
 		});
 
 		it('vflip', () => {
-			const tokens = parse('<vflip>foo</vflip>');
+			const tokens = parseFull('<vflip>foo</vflip>');
 			assert.deepStrictEqual(tokens, [
 				tree('vflip', [
 					text('foo')
@@ -263,7 +263,7 @@ describe('MFM', () => {
 		});
 
 		it('rotate', () => {
-			const tokens = parse('<rotate 90>foo</rotate>');
+			const tokens = parseFull('<rotate 90>foo</rotate>');
 			assert.deepStrictEqual(tokens, [
 				tree('rotate', [
 					text('foo')
@@ -275,7 +275,7 @@ describe('MFM', () => {
 
 		describe('spin', () => {
 			it('text', () => {
-				const tokens = parse('<spin>foo</spin>');
+				const tokens = parseFull('<spin>foo</spin>');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						text('foo')
@@ -286,7 +286,7 @@ describe('MFM', () => {
 			});
 
 			it('かっこ', () => {
-				const tokens = parse('[[[foo]]]');
+				const tokens = parseFull('[[[foo]]]');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						text('foo')
@@ -297,7 +297,7 @@ describe('MFM', () => {
 			});
 
 			it('emoji', () => {
-				const tokens = parse('<spin>:foo:</spin>');
+				const tokens = parseFull('<spin>:foo:</spin>');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
@@ -308,7 +308,7 @@ describe('MFM', () => {
 			});
 
 			it('with attr', () => {
-				const tokens = parse('<spin left>:foo:</spin>');
+				const tokens = parseFull('<spin left>:foo:</spin>');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
@@ -319,7 +319,7 @@ describe('MFM', () => {
 			});
 /*
 			it('multi', () => {
-				const tokens = parse('<spin>:foo:</spin><spin>:foo:</spin>');
+				const tokens = parseFull('<spin>:foo:</spin><spin>:foo:</spin>');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
@@ -335,7 +335,7 @@ describe('MFM', () => {
 			});
 
 			it('nested', () => {
-				const tokens = parse('<spin><spin>:foo:</spin></spin>');
+				const tokens = parseFull('<spin><spin>:foo:</spin></spin>');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						tree('spin', [
@@ -352,7 +352,7 @@ describe('MFM', () => {
 		});
 
 		it('jump', () => {
-			const tokens = parse('<jump>:foo:</jump>');
+			const tokens = parseFull('<jump>:foo:</jump>');
 			assert.deepStrictEqual(tokens, [
 				tree('jump', [
 					leaf('emoji', { name: 'foo' })
@@ -361,7 +361,7 @@ describe('MFM', () => {
 		});
 
 		it('jump かっこ', () => {
-			const tokens = parse('{{{foo}}}');
+			const tokens = parseFull('{{{foo}}}');
 			assert.deepStrictEqual(tokens, [
 				tree('jump', [
 					text('foo')
@@ -371,7 +371,7 @@ describe('MFM', () => {
 
 		describe('motion', () => {
 			it('by triple brackets', () => {
-				const tokens = parse('(((foo)))');
+				const tokens = parseFull('(((foo)))');
 				assert.deepStrictEqual(tokens, [
 					tree('motion', [
 						text('foo')
@@ -380,7 +380,7 @@ describe('MFM', () => {
 			});
 
 			it('by triple brackets (with other texts)', () => {
-				const tokens = parse('bar(((foo)))bar');
+				const tokens = parseFull('bar(((foo)))bar');
 				assert.deepStrictEqual(tokens, [
 					text('bar'),
 					tree('motion', [
@@ -391,7 +391,7 @@ describe('MFM', () => {
 			});
 
 			it('by <motion> tag', () => {
-				const tokens = parse('<motion>foo</motion>');
+				const tokens = parseFull('<motion>foo</motion>');
 				assert.deepStrictEqual(tokens, [
 					tree('motion', [
 						text('foo')
@@ -400,7 +400,7 @@ describe('MFM', () => {
 			});
 
 			it('by <motion> tag (with other texts)', () => {
-				const tokens = parse('bar<motion>foo</motion>bar');
+				const tokens = parseFull('bar<motion>foo</motion>bar');
 				assert.deepStrictEqual(tokens, [
 					text('bar'),
 					tree('motion', [
@@ -413,7 +413,7 @@ describe('MFM', () => {
 
 		describe('mention', () => {
 			it('local', () => {
-				const tokens = parse('@himawari foo');
+				const tokens = parseFull('@himawari foo');
 				assert.deepStrictEqual(tokens, [
 					leaf('mention', {
 						acct: '@himawari',
@@ -426,7 +426,7 @@ describe('MFM', () => {
 			});
 
 			it('remote', () => {
-				const tokens = parse('@hima_sub@namori.net foo');
+				const tokens = parseFull('@hima_sub@namori.net foo');
 				assert.deepStrictEqual(tokens, [
 					leaf('mention', {
 						acct: '@hima_sub@namori.net',
@@ -439,7 +439,7 @@ describe('MFM', () => {
 			});
 
 			it('remote punycode', () => {
-				const tokens = parse('@hima_sub@xn--q9j5bya.xn--zckzah foo');
+				const tokens = parseFull('@hima_sub@xn--q9j5bya.xn--zckzah foo');
 				assert.deepStrictEqual(tokens, [
 					leaf('mention', {
 						acct: '@hima_sub@xn--q9j5bya.xn--zckzah',
@@ -452,12 +452,12 @@ describe('MFM', () => {
 			});
 
 			it('ignore', () => {
-				const tokens = parse('idolm@ster');
+				const tokens = parseFull('idolm@ster');
 				assert.deepStrictEqual(tokens, [
 					text('idolm@ster')
 				]);
 
-				const tokens2 = parse('@a\n@b\n@c');
+				const tokens2 = parseFull('@a\n@b\n@c');
 				assert.deepStrictEqual(tokens2, [
 					leaf('mention', {
 						acct: '@a',
@@ -481,7 +481,7 @@ describe('MFM', () => {
 					})
 				]);
 
-				const tokens3 = parse('**x**@a');
+				const tokens3 = parseFull('**x**@a');
 				assert.deepStrictEqual(tokens3, [
 					tree('bold', [
 						text('x')
@@ -494,7 +494,7 @@ describe('MFM', () => {
 					})
 				]);
 
-				const tokens4 = parse('@\n@v\n@veryverylongusername');
+				const tokens4 = parseFull('@\n@v\n@veryverylongusername');
 				assert.deepStrictEqual(tokens4, [
 					text('@\n'),
 					leaf('mention', {
@@ -516,14 +516,14 @@ describe('MFM', () => {
 
 		describe('hashtag', () => {
 			it('simple', () => {
-				const tokens = parse('#alice');
+				const tokens = parseFull('#alice');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'alice' })
 				]);
 			});
 
 			it('after line break', () => {
-				const tokens = parse('foo\n#alice');
+				const tokens = parseFull('foo\n#alice');
 				assert.deepStrictEqual(tokens, [
 					text('foo\n'),
 					leaf('hashtag', { hashtag: 'alice' })
@@ -531,7 +531,7 @@ describe('MFM', () => {
 			});
 
 			it('with text', () => {
-				const tokens = parse('Strawberry Pasta #alice');
+				const tokens = parseFull('Strawberry Pasta #alice');
 				assert.deepStrictEqual(tokens, [
 					text('Strawberry Pasta '),
 					leaf('hashtag', { hashtag: 'alice' })
@@ -539,7 +539,7 @@ describe('MFM', () => {
 			});
 
 			it('with text (zenkaku)', () => {
-				const tokens = parse('こんにちは#世界');
+				const tokens = parseFull('こんにちは#世界');
 				assert.deepStrictEqual(tokens, [
 					text('こんにちは'),
 					leaf('hashtag', { hashtag: '世界' })
@@ -547,7 +547,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore comma and period', () => {
-				const tokens = parse('Foo #bar, baz #piyo.');
+				const tokens = parseFull('Foo #bar, baz #piyo.');
 				assert.deepStrictEqual(tokens, [
 					text('Foo '),
 					leaf('hashtag', { hashtag: 'bar' }),
@@ -558,7 +558,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore exclamation mark', () => {
-				const tokens = parse('#Foo!');
+				const tokens = parseFull('#Foo!');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'Foo' }),
 					text('!'),
@@ -566,7 +566,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore colon', () => {
-				const tokens = parse('#Foo:');
+				const tokens = parseFull('#Foo:');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'Foo' }),
 					text(':'),
@@ -574,7 +574,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore single quote', () => {
-				const tokens = parse('#foo\'');
+				const tokens = parseFull('#foo\'');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'foo' }),
 					text('\''),
@@ -582,7 +582,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore double quote', () => {
-				const tokens = parse('#foo"');
+				const tokens = parseFull('#foo"');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'foo' }),
 					text('"'),
@@ -590,7 +590,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore square brackets', () => {
-				const tokens = parse('#foo]');
+				const tokens = parseFull('#foo]');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'foo' }),
 					text(']'),
@@ -598,14 +598,14 @@ describe('MFM', () => {
 			});
 
 			it('allow including number', () => {
-				const tokens = parse('#foo123');
+				const tokens = parseFull('#foo123');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'foo123' }),
 				]);
 			});
 
 			it('with brackets', () => {
-				const tokens1 = parse('(#foo)');
+				const tokens1 = parseFull('(#foo)');
 				assert.deepStrictEqual(tokens1, [
 					text('('),
 					leaf('hashtag', { hashtag: 'foo' }),
@@ -614,7 +614,7 @@ describe('MFM', () => {
 			});
 
 			it('with brackets (space before)', () => {
-				const tokens1 = parse('(bar #foo)');
+				const tokens1 = parseFull('(bar #foo)');
 				assert.deepStrictEqual(tokens1, [
 					text('(bar '),
 					leaf('hashtag', { hashtag: 'foo' }),
@@ -623,21 +623,21 @@ describe('MFM', () => {
 			});
 
 			it('disallow number only', () => {
-				const tokens = parse('#123');
+				const tokens = parseFull('#123');
 				assert.deepStrictEqual(tokens, [
 					text('#123'),
 				]);
 			});
 
 			it('disallow number only (with brackets)', () => {
-				const tokens = parse('(#123)');
+				const tokens = parseFull('(#123)');
 				assert.deepStrictEqual(tokens, [
 					text('(#123)'),
 				]);
 			});
 
 			it('ignore slash', () => {
-				const tokens = parse('#foo/bar');
+				const tokens = parseFull('#foo/bar');
 				assert.deepStrictEqual(tokens, [
 					leaf('hashtag', { hashtag: 'foo' }),
 					text('/bar'),
@@ -645,14 +645,14 @@ describe('MFM', () => {
 			});
 
 			it('ignore Keycap Number Sign (U+0023 + U+20E3)', () => {
-				const tokens = parse('#⃣');
+				const tokens = parseFull('#⃣');
 				assert.deepStrictEqual(tokens, [
 					leaf('emoji', { emoji: '#⃣' })
 				]);
 			});
 
 			it('ignore Keycap Number Sign (U+0023 + U+FE0F + U+20E3)', () => {
-				const tokens = parse('#️⃣');
+				const tokens = parseFull('#️⃣');
 				assert.deepStrictEqual(tokens, [
 					leaf('emoji', { emoji: '#️⃣' })
 				]);
@@ -661,14 +661,14 @@ describe('MFM', () => {
 
 		describe('quote', () => {
 			it('basic', () => {
-				const tokens1 = parse('> foo');
+				const tokens1 = parseFull('> foo');
 				assert.deepStrictEqual(tokens1, [
 					tree('quote', [
 						text('foo')
 					], {})
 				]);
 
-				const tokens2 = parse('>foo');
+				const tokens2 = parseFull('>foo');
 				assert.deepStrictEqual(tokens2, [
 					tree('quote', [
 						text('foo')
@@ -677,7 +677,7 @@ describe('MFM', () => {
 			});
 
 			it('series', () => {
-				const tokens = parse('> foo\n\n> bar');
+				const tokens = parseFull('> foo\n\n> bar');
 				assert.deepStrictEqual(tokens, [
 					tree('quote', [
 						text('foo')
@@ -690,14 +690,14 @@ describe('MFM', () => {
 			});
 
 			it('trailing line break', () => {
-				const tokens1 = parse('> foo\n');
+				const tokens1 = parseFull('> foo\n');
 				assert.deepStrictEqual(tokens1, [
 					tree('quote', [
 						text('foo')
 					], {}),
 				]);
 
-				const tokens2 = parse('> foo\n\n');
+				const tokens2 = parseFull('> foo\n\n');
 				assert.deepStrictEqual(tokens2, [
 					tree('quote', [
 						text('foo')
@@ -707,14 +707,14 @@ describe('MFM', () => {
 			});
 
 			it('multiline', () => {
-				const tokens1 = parse('>foo\n>bar');
+				const tokens1 = parseFull('>foo\n>bar');
 				assert.deepStrictEqual(tokens1, [
 					tree('quote', [
 						text('foo\nbar')
 					], {})
 				]);
 
-				const tokens2 = parse('> foo\n> bar');
+				const tokens2 = parseFull('> foo\n> bar');
 				assert.deepStrictEqual(tokens2, [
 					tree('quote', [
 						text('foo\nbar')
@@ -723,14 +723,14 @@ describe('MFM', () => {
 			});
 
 			it('multiline with trailing line break', () => {
-				const tokens1 = parse('> foo\n> bar\n');
+				const tokens1 = parseFull('> foo\n> bar\n');
 				assert.deepStrictEqual(tokens1, [
 					tree('quote', [
 						text('foo\nbar')
 					], {}),
 				]);
 
-				const tokens2 = parse('> foo\n> bar\n\n');
+				const tokens2 = parseFull('> foo\n> bar\n\n');
 				assert.deepStrictEqual(tokens2, [
 					tree('quote', [
 						text('foo\nbar')
@@ -740,7 +740,7 @@ describe('MFM', () => {
 			});
 
 			it('with before and after texts', () => {
-				const tokens = parse('before\n> foo\nafter');
+				const tokens = parseFull('before\n> foo\nafter');
 				assert.deepStrictEqual(tokens, [
 					text('before\n'),
 					tree('quote', [
@@ -751,7 +751,7 @@ describe('MFM', () => {
 			});
 
 			it('multiple quotes', () => {
-				const tokens = parse('> foo\nbar\n\n> foo\nbar\n\n> foo\nbar');
+				const tokens = parseFull('> foo\nbar\n\n> foo\nbar\n\n> foo\nbar');
 				assert.deepStrictEqual(tokens, [
 					tree('quote', [
 						text('foo')
@@ -769,14 +769,14 @@ describe('MFM', () => {
 			});
 
 			it('require line break before ">"', () => {
-				const tokens = parse('foo>bar');
+				const tokens = parseFull('foo>bar');
 				assert.deepStrictEqual(tokens, [
 					text('foo>bar'),
 				]);
 			});
 
 			it('nested', () => {
-				const tokens = parse('>> foo\n> bar');
+				const tokens = parseFull('>> foo\n> bar');
 				assert.deepStrictEqual(tokens, [
 					tree('quote', [
 						tree('quote', [
@@ -788,7 +788,7 @@ describe('MFM', () => {
 			});
 
 			it('trim line breaks', () => {
-				const tokens = parse('foo\n\n>a\n>>b\n>>\n>>>\n>>>c\n>>>\n>d\n\n');
+				const tokens = parseFull('foo\n\n>a\n>>b\n>>\n>>>\n>>>c\n>>>\n>d\n\n');
 				assert.deepStrictEqual(tokens, [
 					text('foo\n\n'),
 					tree('quote', [
@@ -808,14 +808,14 @@ describe('MFM', () => {
 
 		describe('url', () => {
 			it('simple', () => {
-				const tokens = parse('https://example.com');
+				const tokens = parseFull('https://example.com');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://example.com' })
 				]);
 			});
 
 			it('ignore trailing period', () => {
-				const tokens = parse('https://example.com.');
+				const tokens = parseFull('https://example.com.');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://example.com' }),
 					text('.')
@@ -823,7 +823,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore trailing periods', () => {
-				const tokens = parse('https://example.com...');
+				const tokens = parseFull('https://example.com...');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://example.com' }),
 					text('...')
@@ -831,14 +831,14 @@ describe('MFM', () => {
 			});
 
 			it('with comma', () => {
-				const tokens = parse('https://example.com/foo?bar=a,b');
+				const tokens = parseFull('https://example.com/foo?bar=a,b');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://example.com/foo?bar=a,b' })
 				]);
 			});
 
 			it('ignore trailing comma', () => {
-				const tokens = parse('https://example.com/foo, bar');
+				const tokens = parseFull('https://example.com/foo, bar');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://example.com/foo' }),
 					text(', bar')
@@ -846,14 +846,14 @@ describe('MFM', () => {
 			});
 
 			it('with brackets', () => {
-				const tokens = parse('https://example.com/foo(bar)');
+				const tokens = parseFull('https://example.com/foo(bar)');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://example.com/foo(bar)' })
 				]);
 			});
 
 			it('ignore parent brackets', () => {
-				const tokens = parse('(https://example.com/foo)');
+				const tokens = parseFull('(https://example.com/foo)');
 				assert.deepStrictEqual(tokens, [
 					text('('),
 					leaf('url', { url: 'https://example.com/foo' }),
@@ -862,7 +862,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore parent []', () => {
-				const tokens = parse('foo [https://example.com/foo] bar');
+				const tokens = parseFull('foo [https://example.com/foo] bar');
 				assert.deepStrictEqual(tokens, [
 					text('foo ['),
 					leaf('url', { url: 'https://example.com/foo' }),
@@ -871,7 +871,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore parent brackets 2', () => {
-				const tokens = parse('(foo https://example.com/foo)');
+				const tokens = parseFull('(foo https://example.com/foo)');
 				assert.deepStrictEqual(tokens, [
 					text('(foo '),
 					leaf('url', { url: 'https://example.com/foo' }),
@@ -880,7 +880,7 @@ describe('MFM', () => {
 			});
 
 			it('ignore parent brackets with internal brackets', () => {
-				const tokens = parse('(https://example.com/foo(bar))');
+				const tokens = parseFull('(https://example.com/foo(bar))');
 				assert.deepStrictEqual(tokens, [
 					text('('),
 					leaf('url', { url: 'https://example.com/foo(bar)' }),
@@ -889,14 +889,14 @@ describe('MFM', () => {
 			});
 
 			it('ignore non-ascii characters contained url without angle brackets', () => {
-				const tokens = parse('https://大石泉すき.example.com');
+				const tokens = parseFull('https://大石泉すき.example.com');
 				assert.deepStrictEqual(tokens, [
 					text('https://大石泉すき.example.com')
 				]);
 			});
 
 			it('match non-ascii characters contained url with angle brackets', () => {
-				const tokens = parse('<https://大石泉すき.example.com>');
+				const tokens = parseFull('<https://大石泉すき.example.com>');
 				assert.deepStrictEqual(tokens, [
 					leaf('url', { url: 'https://大石泉すき.example.com' })
 				]);
@@ -905,7 +905,7 @@ describe('MFM', () => {
 
 		describe('link', () => {
 			it('simple', () => {
-				const tokens = parse('[foo](https://example.com)');
+				const tokens = parseFull('[foo](https://example.com)');
 				assert.deepStrictEqual(tokens, [
 					tree('link', [
 						text('foo')
@@ -914,7 +914,7 @@ describe('MFM', () => {
 			});
 
 			it('simple (with silent flag)', () => {
-				const tokens = parse('?[foo](https://example.com)');
+				const tokens = parseFull('?[foo](https://example.com)');
 				assert.deepStrictEqual(tokens, [
 					tree('link', [
 						text('foo')
@@ -923,7 +923,7 @@ describe('MFM', () => {
 			});
 
 			it('in text', () => {
-				const tokens = parse('before[foo](https://example.com)after');
+				const tokens = parseFull('before[foo](https://example.com)after');
 				assert.deepStrictEqual(tokens, [
 					text('before'),
 					tree('link', [
@@ -934,7 +934,7 @@ describe('MFM', () => {
 			});
 
 			it('with brackets', () => {
-				const tokens = parse('[foo](https://example.com/foo(bar))');
+				const tokens = parseFull('[foo](https://example.com/foo(bar))');
 				assert.deepStrictEqual(tokens, [
 					tree('link', [
 						text('foo')
@@ -943,7 +943,7 @@ describe('MFM', () => {
 			});
 
 			it('with parent brackets', () => {
-				const tokens = parse('([foo](https://example.com/foo(bar)))');
+				const tokens = parseFull('([foo](https://example.com/foo(bar)))');
 				assert.deepStrictEqual(tokens, [
 					text('('),
 					tree('link', [
@@ -955,19 +955,19 @@ describe('MFM', () => {
 		});
 
 		it('emoji', () => {
-			const tokens1 = parse(':cat:');
+			const tokens1 = parseFull(':cat:');
 			assert.deepStrictEqual(tokens1, [
 				leaf('emoji', { name: 'cat' })
 			]);
 
-			const tokens2 = parse(':cat::cat::cat:');
+			const tokens2 = parseFull(':cat::cat::cat:');
 			assert.deepStrictEqual(tokens2, [
 				leaf('emoji', { name: 'cat' }),
 				leaf('emoji', { name: 'cat' }),
 				leaf('emoji', { name: 'cat' })
 			]);
 
-			const tokens3 = parse('🍎');
+			const tokens3 = parseFull('🍎');
 			assert.deepStrictEqual(tokens3, [
 				leaf('emoji', { emoji: '🍎' })
 			]);
@@ -975,21 +975,21 @@ describe('MFM', () => {
 
 		describe('block code', () => {
 			it('simple', () => {
-				const tokens = parse('```\nvar x = "Strawberry Pasta";\n```');
+				const tokens = parseFull('```\nvar x = "Strawberry Pasta";\n```');
 				assert.deepStrictEqual(tokens, [
 					leaf('blockCode', { code: 'var x = "Strawberry Pasta";', lang: null })
 				]);
 			});
 
 			it('can specify language', () => {
-				const tokens = parse('``` json\n{ "x": 42 }\n```');
+				const tokens = parseFull('``` json\n{ "x": 42 }\n```');
 				assert.deepStrictEqual(tokens, [
 					leaf('blockCode', { code: '{ "x": 42 }', lang: 'json' })
 				]);
 			});
 
 			it('require line break before "```"', () => {
-				const tokens = parse('before```\nfoo\n```');
+				const tokens = parseFull('before```\nfoo\n```');
 				assert.deepStrictEqual(tokens, [
 					text('before'),
 					leaf('inlineCode', { code: '`' }),
@@ -999,7 +999,7 @@ describe('MFM', () => {
 			});
 
 			it('series', () => {
-				const tokens = parse('```\nfoo\n```\n```\nbar\n```\n```\nbaz\n```');
+				const tokens = parseFull('```\nfoo\n```\n```\nbar\n```\n```\nbaz\n```');
 				assert.deepStrictEqual(tokens, [
 					leaf('blockCode', { code: 'foo', lang: null }),
 					leaf('blockCode', { code: 'bar', lang: null }),
@@ -1008,14 +1008,14 @@ describe('MFM', () => {
 			});
 
 			it('ignore internal marker', () => {
-				const tokens = parse('```\naaa```bbb\n```');
+				const tokens = parseFull('```\naaa```bbb\n```');
 				assert.deepStrictEqual(tokens, [
 					leaf('blockCode', { code: 'aaa```bbb', lang: null })
 				]);
 			});
 
 			it('trim after line break', () => {
-				const tokens = parse('```\nfoo\n```\nbar');
+				const tokens = parseFull('```\nfoo\n```\nbar');
 				assert.deepStrictEqual(tokens, [
 					leaf('blockCode', { code: 'foo', lang: null }),
 					text('bar')
@@ -1025,21 +1025,21 @@ describe('MFM', () => {
 
 		describe('inline code', () => {
 			it('simple', () => {
-				const tokens = parse('`var x = "Strawberry Pasta";`');
+				const tokens = parseFull('`var x = "Strawberry Pasta";`');
 				assert.deepStrictEqual(tokens, [
 					leaf('inlineCode', { code: 'var x = "Strawberry Pasta";' })
 				]);
 			});
 
 			it('disallow line break', () => {
-				const tokens = parse('`foo\nbar`');
+				const tokens = parseFull('`foo\nbar`');
 				assert.deepStrictEqual(tokens, [
 					text('`foo\nbar`')
 				]);
 			});
 
 			it('disallow ´', () => {
-				const tokens = parse('`foo´bar`');
+				const tokens = parseFull('`foo´bar`');
 				assert.deepStrictEqual(tokens, [
 					text('`foo´bar`')
 				]);
@@ -1049,7 +1049,7 @@ describe('MFM', () => {
 		it('mathInline', () => {
 			const fomula = 'x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}';
 			const content = `\\(${fomula}\\)`;
-			const tokens = parse(content);
+			const tokens = parseFull(content);
 			assert.deepStrictEqual(tokens, [
 				leaf('mathInline', { formula: fomula })
 			]);
@@ -1059,7 +1059,7 @@ describe('MFM', () => {
 			it('simple', () => {
 				const fomula = 'x = {-b \\pm \\sqrt{b^2-4ac} \\over 2a}';
 				const content = `\\[\n${fomula}\n\\]`;
-				const tokens = parse(content);
+				const tokens = parseFull(content);
 				assert.deepStrictEqual(tokens, [
 					leaf('mathBlock', { formula: fomula })
 				]);
@@ -1067,22 +1067,22 @@ describe('MFM', () => {
 		});
 
 		it('search', () => {
-			const tokens1 = parse('a b c 検索');
+			const tokens1 = parseFull('a b c 検索');
 			assert.deepStrictEqual(tokens1, [
 				leaf('search', { content: 'a b c 検索', query: 'a b c' })
 			]);
 
-			const tokens2 = parse('a b c Search');
+			const tokens2 = parseFull('a b c Search');
 			assert.deepStrictEqual(tokens2, [
 				leaf('search', { content: 'a b c Search', query: 'a b c' })
 			]);
 
-			const tokens3 = parse('a b c search');
+			const tokens3 = parseFull('a b c search');
 			assert.deepStrictEqual(tokens3, [
 				leaf('search', { content: 'a b c search', query: 'a b c' })
 			]);
 
-			const tokens4 = parse('a b c SEARCH');
+			const tokens4 = parseFull('a b c SEARCH');
 			assert.deepStrictEqual(tokens4, [
 				leaf('search', { content: 'a b c SEARCH', query: 'a b c' })
 			]);
@@ -1090,7 +1090,7 @@ describe('MFM', () => {
 
 		describe('title', () => {
 			it('simple', () => {
-				const tokens = parse('【foo】');
+				const tokens = parseFull('【foo】');
 				assert.deepStrictEqual(tokens, [
 					tree('title', [
 						text('foo')
@@ -1099,14 +1099,14 @@ describe('MFM', () => {
 			});
 
 			it('require line break', () => {
-				const tokens = parse('a【foo】');
+				const tokens = parseFull('a【foo】');
 				assert.deepStrictEqual(tokens, [
 					text('a【foo】')
 				]);
 			});
 
 			it('with before and after texts', () => {
-				const tokens = parse('before\n【foo】\nafter');
+				const tokens = parseFull('before\n【foo】\nafter');
 				assert.deepStrictEqual(tokens, [
 					text('before\n'),
 					tree('title', [
@@ -1117,14 +1117,14 @@ describe('MFM', () => {
 			});
 
 			it('ignore multiple title blocks', () => {
-				const tokens = parse('【foo】bar【baz】');
+				const tokens = parseFull('【foo】bar【baz】');
 				assert.deepStrictEqual(tokens, [
 					text('【foo】bar【baz】')
 				]);
 			});
 
 			it('disallow linebreak in title', () => {
-				const tokens = parse('【foo\nbar】');
+				const tokens = parseFull('【foo\nbar】');
 				assert.deepStrictEqual(tokens, [
 					text('【foo\nbar】')
 				]);
@@ -1133,7 +1133,7 @@ describe('MFM', () => {
 
 		describe('center', () => {
 			it('simple', () => {
-				const tokens = parse('<center>foo</center>');
+				const tokens = parseFull('<center>foo</center>');
 				assert.deepStrictEqual(tokens, [
 					tree('center', [
 						text('foo')
@@ -1144,7 +1144,7 @@ describe('MFM', () => {
 
 		describe('strike', () => {
 			it('simple', () => {
-				const tokens = parse('~~foo~~');
+				const tokens = parseFull('~~foo~~');
 				assert.deepStrictEqual(tokens, [
 					tree('strike', [
 						text('foo')
@@ -1154,7 +1154,7 @@ describe('MFM', () => {
 
 			// https://misskey.io/notes/7u1kv5dmia
 			it('ignore internal tilde', () => {
-				const tokens = parse('~~~~~');
+				const tokens = parseFull('~~~~~');
 				assert.deepStrictEqual(tokens, [
 					text('~~~~~')
 				]);
@@ -1163,7 +1163,7 @@ describe('MFM', () => {
 
 		describe('italic', () => {
 			it('<i>', () => {
-				const tokens = parse('<i>foo</i>');
+				const tokens = parseFull('<i>foo</i>');
 				assert.deepStrictEqual(tokens, [
 					tree('italic', [
 						text('foo')
@@ -1172,7 +1172,7 @@ describe('MFM', () => {
 			});
 
 			it('underscore', () => {
-				const tokens = parse('_foo_');
+				const tokens = parseFull('_foo_');
 				assert.deepStrictEqual(tokens, [
 					tree('italic', [
 						text('foo')
@@ -1181,7 +1181,7 @@ describe('MFM', () => {
 			});
 
 			it('simple with asterix', () => {
-				const tokens = parse('*foo*');
+				const tokens = parseFull('*foo*');
 				assert.deepStrictEqual(tokens, [
 					tree('italic', [
 						text('foo')
@@ -1190,42 +1190,42 @@ describe('MFM', () => {
 			});
 
 			it('exlude emotes', () => {
-				const tokens = parse('*.*');
+				const tokens = parseFull('*.*');
 				assert.deepStrictEqual(tokens, [
 					text("*.*"),
 				]);
 			});
 
 			it('mixed', () => {
-				const tokens = parse('_foo*');
+				const tokens = parseFull('_foo*');
 				assert.deepStrictEqual(tokens, [
 					text('_foo*'),
 				]);
 			});
 
 			it('mixed', () => {
-				const tokens = parse('*foo_');
+				const tokens = parseFull('*foo_');
 				assert.deepStrictEqual(tokens, [
 					text('*foo_'),
 				]);
 			});
 
 			it('ignore snake_case string', () => {
-				const tokens = parse('foo_bar_baz');
+				const tokens = parseFull('foo_bar_baz');
 				assert.deepStrictEqual(tokens, [
 					text('foo_bar_baz'),
 				]);
 			});
 
 			it('require spaces', () => {
-				const tokens = parse('４日目_L38b a_b');
+				const tokens = parseFull('４日目_L38b a_b');
 				assert.deepStrictEqual(tokens, [
 					text('４日目_L38b a_b'),
 				]);
 			});
 
 			it('newline sandwich', () => {
-				const tokens = parse('foo\n_bar_\nbaz');
+				const tokens = parseFull('foo\n_bar_\nbaz');
 				assert.deepStrictEqual(tokens, [
 					text('foo\n'),
 					tree('italic', [
@@ -1270,7 +1270,7 @@ describe('MFM', () => {
 	});
 
 	it('code block with quote', () => {
-		const tokens = parse('> foo\n```\nbar\n```');
+		const tokens = parseFull('> foo\n```\nbar\n```');
 		assert.deepStrictEqual(tokens, [
 			tree('quote', [
 				text('foo')
@@ -1280,7 +1280,7 @@ describe('MFM', () => {
 	});
 
 	it('quote between two code blocks', () => {
-		const tokens = parse('```\nbefore\n```\n> foo\n```\nafter\n```');
+		const tokens = parseFull('```\nbefore\n```\n> foo\n```\nafter\n```');
 		assert.deepStrictEqual(tokens, [
 			leaf('blockCode', { code: 'before', lang: null }),
 			tree('quote', [

--- a/test/mfm/to-html.ts
+++ b/test/mfm/to-html.ts
@@ -10,19 +10,19 @@
 
 import * as assert from 'assert';
 
-import { parse } from '../../src/mfm/parse';
+import { parseFull } from '../../src/mfm/parse';
 import { toHtml } from '../../src/mfm/to-html';
 
 describe('toHtml', () => {
 	it('br', () => {
 		const input = 'foo\nbar\nbaz';
 		const output = '<p><span>foo<br>bar<br>baz</span></p>';
-		assert.equal(toHtml(parse(input)!), output);
+		assert.equal(toHtml(parseFull(input)!), output);
 	});
 
 	it('br alt', () => {
 		const input = 'foo\r\nbar\rbaz';
 		const output = '<p><span>foo<br>bar<br>baz</span></p>';
-		assert.equal(toHtml(parse(input)!), output);
+		assert.equal(toHtml(parseFull(input)!), output);
 	});
 });

--- a/test/toString.ts
+++ b/test/toString.ts
@@ -8,95 +8,95 @@
  * > mocha test/toString.ts --require ts-node/register -g 'test name'
  */
 import * as assert from 'assert';
-import { parse } from '../src/mfm/parse';
+import { parseFull } from '../src/mfm/parse';
 import { toString } from '../src/mfm/to-string';
 
 describe('toString', () => {
 	it('太字', () => {
-		assert.deepStrictEqual(toString(parse('**太字**')), '**太字**');
+		assert.deepStrictEqual(toString(parseFull('**太字**')), '**太字**');
 	});
 	it('中央揃え', () => {
-		assert.deepStrictEqual(toString(parse('<center>中央揃え</center>')), '<center>中央揃え</center>');
+		assert.deepStrictEqual(toString(parseFull('<center>中央揃え</center>')), '<center>中央揃え</center>');
 	});
 	it('打ち消し線', () => {
-		assert.deepStrictEqual(toString(parse('~~打ち消し線~~')), '~~打ち消し線~~');
+		assert.deepStrictEqual(toString(parseFull('~~打ち消し線~~')), '~~打ち消し線~~');
 	});
 	it('小さい字', () => {
-		assert.deepStrictEqual(toString(parse('<small>小さい字</small>')), '<small>小さい字</small>');
+		assert.deepStrictEqual(toString(parseFull('<small>小さい字</small>')), '<small>小さい字</small>');
 	});
 	it('モーション', () => {
-		assert.deepStrictEqual(toString(parse('<motion>モーション</motion>')), '<motion>モーション</motion>');
+		assert.deepStrictEqual(toString(parseFull('<motion>モーション</motion>')), '<motion>モーション</motion>');
 	});
 	it('モーション2', () => {
-		assert.deepStrictEqual(toString(parse('(((モーション)))')), '<motion>モーション</motion>');
+		assert.deepStrictEqual(toString(parseFull('(((モーション)))')), '<motion>モーション</motion>');
 	});
 	it('ビッグ＋', () => {
-		assert.deepStrictEqual(toString(parse('*** ビッグ＋ ***')), '*** ビッグ＋ ***');
+		assert.deepStrictEqual(toString(parseFull('*** ビッグ＋ ***')), '*** ビッグ＋ ***');
 	});
 	it('回転', () => {
-		assert.deepStrictEqual(toString(parse('<spin>回転</spin>')), '<spin>回転</spin>');
+		assert.deepStrictEqual(toString(parseFull('<spin>回転</spin>')), '<spin>回転</spin>');
 	});
 	it('右回転', () => {
-		assert.deepStrictEqual(toString(parse('<spin right>右回転</spin>')), '<spin right>右回転</spin>');
+		assert.deepStrictEqual(toString(parseFull('<spin right>右回転</spin>')), '<spin right>右回転</spin>');
 	});
 	it('左回転', () => {
-		assert.deepStrictEqual(toString(parse('<spin left>左回転</spin>')), '<spin left>左回転</spin>');
+		assert.deepStrictEqual(toString(parseFull('<spin left>左回転</spin>')), '<spin left>左回転</spin>');
 	});
 	it('往復回転', () => {
-		assert.deepStrictEqual(toString(parse('<spin alternate>往復回転</spin>')), '<spin alternate>往復回転</spin>');
+		assert.deepStrictEqual(toString(parseFull('<spin alternate>往復回転</spin>')), '<spin alternate>往復回転</spin>');
 	});
 	it('ジャンプ', () => {
-		assert.deepStrictEqual(toString(parse('<jump>ジャンプ</jump>')), '<jump>ジャンプ</jump>');
+		assert.deepStrictEqual(toString(parseFull('<jump>ジャンプ</jump>')), '<jump>ジャンプ</jump>');
 	});
 	it('コードブロック', () => {
-		assert.deepStrictEqual(toString(parse('```\nコードブロック\n```')), '```\nコードブロック\n```');
+		assert.deepStrictEqual(toString(parseFull('```\nコードブロック\n```')), '```\nコードブロック\n```');
 	});
 	it('インラインコード', () => {
-		assert.deepStrictEqual(toString(parse('`インラインコード`')), '`インラインコード`');
+		assert.deepStrictEqual(toString(parseFull('`インラインコード`')), '`インラインコード`');
 	});
 	it('引用行', () => {
-		assert.deepStrictEqual(toString(parse('>引用行')), '>引用行');
+		assert.deepStrictEqual(toString(parseFull('>引用行')), '>引用行');
 	});
 	it('検索', () => {
-		assert.deepStrictEqual(toString(parse('検索 [search]')), '検索 [search]');
+		assert.deepStrictEqual(toString(parseFull('検索 [search]')), '検索 [search]');
 	});
 	it('リンク', () => {
-		assert.deepStrictEqual(toString(parse('[リンク](http://example.com)')), '[リンク](http://example.com)');
+		assert.deepStrictEqual(toString(parseFull('[リンク](http://example.com)')), '[リンク](http://example.com)');
 	});
 	it('詳細なしリンク', () => {
-		assert.deepStrictEqual(toString(parse('?[詳細なしリンク](http://example.com)')), '?[詳細なしリンク](http://example.com)');
+		assert.deepStrictEqual(toString(parseFull('?[詳細なしリンク](http://example.com)')), '?[詳細なしリンク](http://example.com)');
 	});
 	it('【タイトル】', () => {
-		assert.deepStrictEqual(toString(parse('【タイトル】')), '[タイトル]');
+		assert.deepStrictEqual(toString(parseFull('【タイトル】')), '[タイトル]');
 	});
 	it('[タイトル]', () => {
-		assert.deepStrictEqual(toString(parse('[タイトル]')), '[タイトル]');
+		assert.deepStrictEqual(toString(parseFull('[タイトル]')), '[タイトル]');
 	});
 	it('インライン数式', () => {
-		assert.deepStrictEqual(toString(parse('\\(インライン数式\\)')), '\\(インライン数式\\)');
+		assert.deepStrictEqual(toString(parseFull('\\(インライン数式\\)')), '\\(インライン数式\\)');
 	});
 	it('ブロック数式', () => {
-		assert.deepStrictEqual(toString(parse('\\\[\nブロック数式\n\]\\')), '\\\[\nブロック数式\n\]\\');
+		assert.deepStrictEqual(toString(parseFull('\\\[\nブロック数式\n\]\\')), '\\\[\nブロック数式\n\]\\');
 	});
 	it('上下反転', () => {
-		assert.deepStrictEqual(toString(parse('<vflip>上下反転</vflip>')), '<vflip>上下反転</vflip>');
+		assert.deepStrictEqual(toString(parseFull('<vflip>上下反転</vflip>')), '<vflip>上下反転</vflip>');
 	});
 	it('指定角度回転', () => {
-		assert.deepStrictEqual(toString(parse('<rotate 30>指定角度回転</rotate>')), '<rotate 30>指定角度回転</rotate>');
+		assert.deepStrictEqual(toString(parseFull('<rotate 30>指定角度回転</rotate>')), '<rotate 30>指定角度回転</rotate>');
 	});
 	it('X軸回転', () => {
-		assert.deepStrictEqual(toString(parse('<xspin>X軸回転</xspin>')), '<xspin>X軸回転</xspin>');
+		assert.deepStrictEqual(toString(parseFull('<xspin>X軸回転</xspin>')), '<xspin>X軸回転</xspin>');
 	});
 	it('Y軸回転', () => {
-		assert.deepStrictEqual(toString(parse('<yspin>Y軸回転</yspin>')), '<yspin>Y軸回転</yspin>');
+		assert.deepStrictEqual(toString(parseFull('<yspin>Y軸回転</yspin>')), '<yspin>Y軸回転</yspin>');
 	});
 	it('マーキー', () => {
-		assert.deepStrictEqual(toString(parse('<marquee>マーキー (右から左へ)</marquee>')), '<marquee>マーキー (右から左へ)</marquee>');
+		assert.deepStrictEqual(toString(parseFull('<marquee>マーキー (右から左へ)</marquee>')), '<marquee>マーキー (右から左へ)</marquee>');
 	});
 	it('マーキー2', () => {
-		assert.deepStrictEqual(toString(parse('<marquee reverse>マーキー (左から右へ)</marquee>')), '<marquee reverse>マーキー (左から右へ)</marquee>');
+		assert.deepStrictEqual(toString(parseFull('<marquee reverse>マーキー (左から右へ)</marquee>')), '<marquee reverse>マーキー (左から右へ)</marquee>');
 	});
 	it('マーキー3', () => {
-		assert.deepStrictEqual(toString(parse('<marquee reverse-slide>マーキー (左から出てきて右で停止)</marquee>')), '<marquee reverse-slide>マーキー (左から出てきて右で停止)</marquee>');
+		assert.deepStrictEqual(toString(parseFull('<marquee reverse-slide>マーキー (左から出てきて右で停止)</marquee>')), '<marquee reverse-slide>マーキー (左から出てきて右で停止)</marquee>');
 	});
 });


### PR DESCRIPTION
## Summary
parse => parseFull
Add parseBasic: 装飾系を処理しないパーサー (メンション, タグ, URL, リンク, コード のみ)

MFM構文の中のURLが展開されないのを修正

(クライアント) URL展開処理時にフルMFMパースを行わないように
(クライアント) 投稿フォームのメンション抽出でフルMFMパースを行わないように
(クライアント) 投稿で装飾系のMFMが使われてない場合にはフルMFMパースを行わないように
(サーバー) メンション/タグ/絵文字抽出でフルMFMパースを行わないように

MFM link のラベルがURLとして解釈できる場合にネストされたaエレメントを生成してしまうのを修正 Fix #2220
MFM link で偽装されたラベルは無視するように