### PR TITLE
Update LD Signature

### DIFF
--- a/src/misc/gen-key-pair.ts
+++ b/src/misc/gen-key-pair.ts
@@ -19,7 +19,7 @@ export async function genRsaKeyPair(modulusLength = 2048) {
 	});
 }
 
-export async function genEcKeyPair(namedCurve: 'prime256v1' | 'secp384r1' | 'secp521r1' | 'curve25519' = 'prime256v1') {
+export async function genEcKeyPair(namedCurve: 'prime256v1' | 'secp384r1' | 'secp521r1' = 'prime256v1') {
 	return await generateKeyPair('ec', {
 		namedCurve,
 		publicKeyEncoding: {

--- a/src/remote/activitypub/misc/ld-signature.ts
+++ b/src/remote/activitypub/misc/ld-signature.ts
@@ -1,44 +1,54 @@
 import * as crypto from 'crypto';
 import * as jsonld from 'jsonld';
 import { CONTEXTS } from './contexts';
-import { getJson } from '../../../misc/fetch';
 
-// RsaSignature2017 based from https://github.com/transmute-industries/RsaSignature2017
+// https://docs.joinmastodon.org/spec/security/#ld
+// https://github.com/transmute-industries/RsaSignature2017
+// https://socialhub.activitypub.rocks/t/making-sense-of-rsasignature2017/347
+
+type RsaSignature2017Options = {
+	type: 'RsaSignature2017';
+	creator: string;
+	domain?: string;
+	nonce?: string;
+	created: string;
+};
+
+type RsaSignature2017 = RsaSignature2017Options & {
+	signatureValue: string;
+};
+
+function isRsaSignature2017(signature: any): signature is RsaSignature2017 {
+	return signature?.type === 'RsaSignature2017';
+}
 
 export class LdSignature {
 	public debug = false;
 	public preLoad = true;
-	public loderTimeout = 10 * 1000;
+	public fetchFunc?: (url: string) => Promise<any>;
 
 	constructor() {
 	}
 
-	public async signRsaSignature2017(data: any, privateKey: string, creator: string, domain?: string, created?: Date): Promise<any> {
-		const options = {
+	public async signRsaSignature2017(data: any, privateKeyPem: string, creator: string, domain?: string, created?: Date) {
+		const options: RsaSignature2017Options = {
 			type: 'RsaSignature2017',
 			creator,
 			domain,
 			nonce: crypto.randomBytes(16).toString('hex'),
 			created: (created || new Date()).toISOString()
-		} as {
-			type: string;
-			creator: string;
-			domain: string;
-			nonce: string;
-			created: string;
 		};
 
 		if (!domain) {
 			delete options.domain;
 		}
 
+		const privateKey = crypto.createPrivateKey(privateKeyPem);
+		if (privateKey.asymmetricKeyType !== 'rsa') throw new Error('privateKey is not rsa');
+
 		const toBeSigned = await this.createVerifyData(data, options);
 
-		const signer = crypto.createSign('sha256');
-		signer.update(toBeSigned);
-		signer.end();
-
-		const signature = signer.sign(privateKey);
+		const signature = crypto.sign('sha256', Buffer.from(toBeSigned), privateKey);
 
 		return {
 			...data,
@@ -49,28 +59,34 @@ export class LdSignature {
 		};
 	}
 
-	public async verifyRsaSignature2017(data: any, publicKey: string): Promise<boolean> {
-		const toBeSigned = await this.createVerifyData(data, data.signature);
-		const verifier = crypto.createVerify('sha256');
-		verifier.update(toBeSigned);
-		return verifier.verify(publicKey, data.signature.signatureValue, 'base64');
+	public async verifyRsaSignature2017(data: any, publicKeyPem: string): Promise<boolean> {
+		const signature = data.signature;
+		if (!isRsaSignature2017(signature)) throw new Error('signature is not RsaSignature2017');
+
+		const publicKey = crypto.createPublicKey(publicKeyPem);
+		if (publicKey.asymmetricKeyType !== 'rsa') throw new Error('publicKey is not rsa');
+
+		const toBeSigned = await this.createVerifyData(data, signature);
+
+		return crypto.verify('sha256', Buffer.from(toBeSigned), publicKey, Buffer.from(signature.signatureValue, 'base64'));
 	}
 
-	public async createVerifyData(data: any, options: any) {
+	public async createVerifyData(data: any, options: RsaSignature2017Options | RsaSignature2017) {
 		const transformedOptions = {
 			...options,
 			'@context': 'https://w3id.org/identity/v1'
 		};
 		delete transformedOptions['type'];
-		delete transformedOptions['id'];
-		delete transformedOptions['signatureValue'];
+		delete (transformedOptions as any)['id'];
+		delete (transformedOptions as any)['signatureValue'];
 		const canonizedOptions = await this.normalize(transformedOptions);
 		const optionsHash = this.sha256(canonizedOptions);
+
 		const transformedData = { ...data };
 		delete transformedData['signature'];
 		const cannonidedData = await this.normalize(transformedData);
-		if (this.debug) console.debug(`cannonidedData: ${cannonidedData}`);
 		const documentHash = this.sha256(cannonidedData);
+
 		const verifyData = `${optionsHash}${documentHash}`;
 		return verifyData;
 	}
@@ -78,6 +94,7 @@ export class LdSignature {
 	public async normalize(data: any) {
 		const customLoader = this.getLoader();
 		return await jsonld.normalize(data, {
+			algorithm: 'URDNA2015',
 			documentLoader: customLoader
 		});
 	}
@@ -97,8 +114,14 @@ export class LdSignature {
 				}
 			}
 
+			if (!this.fetchFunc) {
+				if (this.debug) console.debug(`REJECT: ${url}`);
+				throw `REJECT: ${url}`;
+			}
+
 			if (this.debug) console.debug(`FETCH: ${url}`);
-			const document = await this.fetchDocument(url);
+			const document = await this.fetchFunc(url);
+
 			return {
 				contextUrl: null,
 				document: document,
@@ -107,13 +130,9 @@ export class LdSignature {
 		};
 	}
 
-	private async fetchDocument(url: string) {
-		return await getJson(url, 'application/ld+json, application/json', this.loderTimeout);
-	}
-
 	public sha256(data: string): string {
 		const hash = crypto.createHash('sha256');
 		hash.update(data);
-		return hash.digest('hex');
+		return hash.digest('hex').toLowerCase();
 	}
 }

--- a/src/remote/activitypub/misc/ld-signature.ts
+++ b/src/remote/activitypub/misc/ld-signature.ts
@@ -2,6 +2,7 @@ import * as crypto from 'crypto';
 import * as jsonld from 'jsonld';
 import { CONTEXTS } from './contexts';
 
+// https://github.com/mei23/ldsig
 // https://docs.joinmastodon.org/spec/security/#ld
 // https://github.com/transmute-industries/RsaSignature2017
 // https://socialhub.activitypub.rocks/t/making-sense-of-rsasignature2017/347


### PR DESCRIPTION
## Summary
https://github.com/mei23/ldsig をベースに最新化

- 軽くtypeを付ける
- normalize中のremote fetch functionを外部指定するように。
  また、既定では未指定にして (id_v1, security_v1, activitystreams 以外の) remote loadが必要な場合は拒否するように。
  少なくとも Mastdon, Misskey のrelayでは動くし、そもそも署名を外部リクエストに依存させるのは変な気がした。
- verify時に署名アルゴリズムがRsaSignature2017であることを確認するように。
- sign/verify時に鍵のアルゴリズムがRSAであることを確認するように。
- `crypto.createSign`ではなく`crypto.sign`を使うように (verifyも同様)
  ​EdDSAでは後者しか使えないため (今はRSAのみだけど)
- normalizeのアルゴリズムがURDNA2015であることをコード上で明確に、挙動変更なし。
- sha256のhex valueがLowerCaseであることをコード上で明確に、挙動変更なし。 
- テストを追加
- EcKeyでcurve25519は使えないので削除