### PR TITLE
リレーにLikeを送るように

### DIFF
--- a/src/remote/activitypub/renderer/like.ts
+++ b/src/remote/activitypub/renderer/like.ts
@@ -11,6 +11,7 @@ export const renderLike = async (noteReaction: INoteReaction, note: INote) => {
 		id: `${config.url}/likes/${noteReaction._id}`,
 		actor: `${config.url}/users/${noteReaction.userId}`,
 		object: note.uri ? note.uri : `${config.url}/notes/${noteReaction.noteId}`,
+		published: noteReaction.createdAt.toISOString(),
 		content: reaction,
 		_misskey_reaction: reaction
 	} as any;

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -12,6 +12,7 @@ import perUserReactionsChart from '../../../services/chart/per-user-reactions';
 import { toDbReaction, decodeReaction } from '../../../misc/reaction-lib';
 import deleteReaction from './delete';
 import { packEmojis } from '../../../misc/pack-emojis';
+import { deliverToRelays } from '../../relay';
 
 export default async (user: IUser, note: INote, reaction?: string, dislike = false) => {
 	reaction = await toDbReaction(reaction, true, user.host);
@@ -107,7 +108,7 @@ export default async (user: IUser, note: INote, reaction?: string, dislike = fal
 		const content = renderActivity(await renderLike(inserted, note), user);
 		if (isRemoteUser(note._user)) deliverToUser(user, content, note._user);
 		deliverToFollowers(user, content, true);
-		//deliverToRelays(user, content);
+		deliverToRelays(user, content);
 	}
 	//#endregion
 

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -8,6 +8,7 @@ import { renderActivity } from '../../../remote/activitypub/renderer';
 import { deliverToUser, deliverToFollowers } from '../../../remote/activitypub/deliver-manager';
 import { IdentifiableError } from '../../../misc/identifiable-error';
 import { decodeReaction } from '../../../misc/reaction-lib';
+import { deliverToRelays } from '../../relay';
 
 export default async (user: IUser, note: INote) => {
 	// if already unreacted
@@ -49,7 +50,7 @@ export default async (user: IUser, note: INote) => {
 		const content = renderActivity(renderUndo(await renderLike(exist, note), user), user);
 		if (isRemoteUser(note._user)) deliverToUser(user, content, note._user);
 		deliverToFollowers(user, content, true);
-		//deliverToRelays(user, content);
+		deliverToRelays(user, content);
 	}
 	//#endregion
 


### PR DESCRIPTION
## Summary
Resolve #3105
Likeのforwardは [pub-relay (fork by noellabo)](https://github.com/noellabo/pub-relay/) が対応している。
`published`は付いてないと`Skip old activity`で除外されてしまうので追加。
受信側のMisskeyの対応は特に不要。

`mei-m544`はLikeされたNoteがない時は引っ張ってくるけど、v12とかは挙動が違うかも。