### PR TITLE
ドライブのフォルダを横とかに

### DIFF
--- a/src/client/app/desktop/views/components/drive.folder.vue
+++ b/src/client/app/desktop/views/components/drive.folder.vue
@@ -18,7 +18,7 @@
 	<p class="name">
 		<template v-if="hover"><fa :icon="['far', 'folder-open']" fixed-width/></template>
 		<template v-if="!hover"><fa :icon="['far', 'folder']" fixed-width/></template>
-		{{ folder.name }}
+		{{ this.parent ? '..' : folder.name }}
 	</p>
 </div>
 </template>
@@ -29,7 +29,7 @@ import i18n from '../../../i18n';
 
 export default Vue.extend({
 	i18n: i18n('desktop/views/components/drive.folder.vue'),
-	props: ['folder'],
+	props: ['folder', 'parent'],
 	data() {
 		return {
 			hover: false,
@@ -43,7 +43,7 @@ export default Vue.extend({
 			return this.$parent;
 		},
 		title(): string {
-			return this.folder.name;
+			return this.folder?.name || '..';
 		}
 	},
 	methods: {

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -31,7 +31,7 @@
 				<x-file v-for="file in files" :key="file.id" class="file" :file="file"/>
 				<ui-button v-if="moreFiles" @click="fetchMoreFiles">{{ $t('@.load-more') }}</ui-button>
 			</div>
-			<div class="files" v-else-if="!fetching">
+			<div class="empty" v-else-if="!fetching">
 				<p v-if="draghover">{{ $t('empty-draghover') }}</p>
 				<p v-else>{{ $t('empty-folder') }}</p>
 			</div>
@@ -685,6 +685,7 @@ export default Vue.extend({
 				padding 8px
 
 			> .files
+			> .empty
 				display flex
 				flex-wrap wrap
 				overflow-y auto

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -22,22 +22,17 @@
 	>
 		<div class="selection" ref="selection"></div>
 		<div class="contents" ref="contents">
-			<div class="folders" ref="foldersContainer" v-if="folders.length > 0 || moreFolders">
+			<div class="folders" ref="foldersContainer">
 				<x-folder v-for="folder in folders" :key="folder.id" class="folder" :folder="folder"/>
-				<!-- SEE: https://stackoverflow.com/questions/18744164/flex-box-align-last-row-to-grid -->
-				<div class="padding" v-for="n in 16"></div>
 				<ui-button v-if="moreFolders">{{ $t('@.load-more') }}</ui-button>
 			</div>
 			<div class="files" ref="filesContainer" v-if="files.length > 0 || moreFiles">
 				<x-file v-for="file in files" :key="file.id" class="file" :file="file"/>
-				<!-- SEE: https://stackoverflow.com/questions/18744164/flex-box-align-last-row-to-grid -->
-				<div class="padding" v-for="n in 16"></div>
 				<ui-button v-if="moreFiles" @click="fetchMoreFiles">{{ $t('@.load-more') }}</ui-button>
 			</div>
-			<div class="empty" v-if="files.length == 0 && !moreFiles && folders.length == 0 && !moreFolders && !fetching">
+			<div class="files" v-else-if="!fetching">
 				<p v-if="draghover">{{ $t('empty-draghover') }}</p>
-				<p v-if="!draghover && folder == null"><strong>{{ $t('empty-drive') }}</strong><br/>{{ $t('empty-drive-description') }}</p>
-				<p v-if="!draghover && folder != null">{{ $t('empty-folder') }}</p>
+				<p v-else>{{ $t('empty-folder') }}</p>
 			</div>
 		</div>
 		<div class="fetching" v-if="fetching">
@@ -641,7 +636,6 @@ export default Vue.extend({
 						margin 0
 
 	> .main
-		padding 8px
 		height calc(100% - 38px)
 		overflow auto
 		background var(--desktopDriveBg)
@@ -670,17 +664,31 @@ export default Vue.extend({
 			border solid 1px var(--primary)
 			background var(--primaryAlpha05)
 			pointer-events none
-
+ 
 		> .contents
+			display flex
+			height 100%
+			overflow hidden
 
 			> .folders
+				display flex
+				flex-direction column
+				overflow-y auto
+				overflow-x hidden
+				width 200px
+				padding 8px
+
 			> .files
 				display flex
 				flex-wrap wrap
+				overflow-y auto
+				width 100%
+				padding 8px
 
+			> .folders
+			> .files
 				> .folder
 				> .file
-					flex-grow 1
 					width 144px
 					margin 4px
 
@@ -688,7 +696,6 @@ export default Vue.extend({
 					flex-grow 1
 					pointer-events none
 					width 144px + 8px // 8px is margin
-
 			> .empty
 				padding 16px
 				text-align center

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -23,7 +23,8 @@
 		<div class="selection" ref="selection"></div>
 		<div class="contents" ref="contents">
 			<div class="folders" ref="foldersContainer">
-				<x-folder v-for="folder in folders" :key="folder.id" class="folder" :folder="folder"/>
+				<x-folder class="folder" v-if="folder != null" :key="parentFolder ? parentFolder.id : null" :folder="parentFolder" :parent="true"/>
+				<x-folder class="folder" v-for="folder in folders" :key="folder.id" :folder="folder"/>
 				<ui-button v-if="moreFolders">{{ $t('@.load-more') }}</ui-button>
 			</div>
 			<div class="files" ref="filesContainer" v-if="files.length > 0 || moreFiles">
@@ -130,6 +131,11 @@ export default Vue.extend({
 	},
 	beforeDestroy() {
 		this.connection.dispose();
+	},
+	computed: {
+		parentFolder(): any {
+			return this.hierarchyFolders[this.hierarchyFolders.length - 1];
+		}
 	},
 	methods: {
 		onContextmenu(e) {

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -520,8 +520,8 @@ export default Vue.extend({
 			let fetchedFolders = null;
 			let fetchedFiles = null;
 
-			const foldersMax = 30;
-			const filesMax = 30;
+			const foldersMax = 24;
+			const filesMax = 24;
 
 			// フォルダ一覧取得
 			this.$root.api('drive/folders', {
@@ -565,7 +565,7 @@ export default Vue.extend({
 		fetchMoreFiles() {
 			this.fetching = true;
 
-			const max = 30;
+			const max = 24;
 
 			// ファイル一覧取得
 			this.$root.api('drive/files', {

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -670,7 +670,7 @@ export default Vue.extend({
 			border solid 1px var(--primary)
 			background var(--primaryAlpha05)
 			pointer-events none
- 
+
 		> .contents
 			display flex
 			height 100%
@@ -702,6 +702,7 @@ export default Vue.extend({
 					flex-grow 1
 					pointer-events none
 					width 144px + 8px // 8px is margin
+
 			> .empty
 				padding 16px
 				text-align center

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -706,7 +706,7 @@ export default Vue.extend({
 
 			> .empty
 				padding 16px
-				text-align center
+				justify-content center
 				color #999
 				pointer-events none
 

--- a/src/server/api/endpoints/drive/files/create.ts
+++ b/src/server/api/endpoints/drive/files/create.ts
@@ -93,7 +93,7 @@ export default define(meta, async (ps, user, app, file, cleanup) => {
 
 	try {
 		const driveFile = await addFile({ user, path: file.path, name, folderId: ps.folderId, force: ps.force, sensitive: ps.isSensitive });
-		return pack(driveFile, { self: true });
+		return pack(driveFile, { detail: true, self: true });
 	} catch (e) {
 		apiLogger.error(e);
 		throw new ApiError();


### PR DESCRIPTION
## Summary
#3770
- デスクトップのドライブのフォルダを横に表示するように
  - フォルダ一覧に`..`を表示するように
- サブフォルダにファイルを追加したた時に表示が更新されないのを修正