### PR TITLE
DNSキャッシュをやめる Resolve #4021

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
 		"bootstrap-vue": "2.22.0",
 		"browser-image-resizer": "git+https://github.com/misskey-dev/browser-image-resizer#v2.2.1-misskey.2",
 		"bull": "4.9.0",
-		"cacheable-lookup": "6.1.0",
 		"cafy": "15.2.1",
 		"chalk": "4.1.2",
 		"cheerio": "0.22.0",

--- a/src/misc/dns.ts
+++ b/src/misc/dns.ts
@@ -1,0 +1,29 @@
+import * as dns from 'dns';
+
+type LookupOneCallback = (err: Error | null, address?: string, family?: number) => void;
+
+export function lookup(hostname: string, options: { family?: number, hints?: number }, callback: LookupOneCallback) {
+	if (options.family === 4) {
+		dns.promises.resolve4(hostname).then(addresses => {
+			callback(null, addresses[0], 4);
+		}).catch(err => {
+			callback(err);
+		});
+	} else if (options.family === 6) {
+		dns.promises.resolve6(hostname).then(addresses => {
+			callback(null, addresses[0], 6);
+		}).catch(err => {
+			callback(err);
+		});
+	} else {
+		dns.promises.resolve4(hostname).then(addresses => {
+			callback(null, addresses[0], 4);
+		}).catch(err4 => {
+			dns.promises.resolve6(hostname).then(addresses => {
+				callback(null, addresses[0], 6);
+			}).catch(err6 => {
+				callback(err6);
+			});
+		});
+	}
+}

--- a/src/misc/fetch.ts
+++ b/src/misc/fetch.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import CacheableLookup from 'cacheable-lookup';
+import { lookup } from './dns';
 import got, * as Got from 'got';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import config from '../config';
@@ -118,20 +118,13 @@ function objectAssignWithLcKey(a: Record<string, string>, b: Record<string, stri
 	return Object.assign(lcObjectKey(a), lcObjectKey(b));
 }
 
-//#region Agent
-const cache = new CacheableLookup({
-	maxTtl: 3600,	// 1hours
-	errorTtl: 30,	// 30secs
-	lookup: false,	// nativeのdns.lookupにfallbackしない
-});
-
 /**
  * Get http non-proxy agent
  */
 const _http = new http.Agent({
 	keepAlive: true,
 	keepAliveMsecs: 30 * 1000,
-	lookup: cache.lookup,	// DefinitelyTyped issues
+	lookup: lookup,
 } as http.AgentOptions);
 
 /**
@@ -140,7 +133,7 @@ const _http = new http.Agent({
 const _https = new https.Agent({
 	keepAlive: true,
 	keepAliveMsecs: 30 * 1000,
-	lookup: cache.lookup,
+	lookup: lookup,
 } as https.AgentOptions);
 
 const maxSockets = Math.max(256, config.deliverJobConcurrency || 128);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,11 +1916,6 @@ cache-content-type@^1.0.0:
     mime-types "^2.1.18"
     ylru "^1.2.0"
 
-cacheable-lookup@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz#0330a543471c61faa4e9035db583aad753b36385"
-  integrity sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==
-
 cacheable-lookup@^5.0.3:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"


### PR DESCRIPTION
## Summary
Resolve #4021

アプリでのDNSキャッシュは、ほとんどの環境で不要なためしないようにする。
ただのlookupに戻すとパフォーマンスが悪いため、resolve* へのラッパーを作成する。
特別な挙動としてIPv4が常に優先になる。