### PR TITLE
ファイル名にUUIDを使用するように

### DIFF
--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -24,7 +24,7 @@ import { getDriveConfig } from '../../misc/get-drive-config';
 import * as S3 from 'aws-sdk/clients/s3';
 import { getS3 } from './s3';
 import * as sharp from 'sharp';
-import { genFid } from '../../misc/id/fid';
+import { v4 as uuid } from 'uuid';
 import { InternalStorage } from './internal-storage';
 
 const logger = driveLogger.createSubLogger('register', 'yellow');
@@ -64,7 +64,7 @@ async function save(path: string, name: string, info: FileInfo, metadata: IMetad
 			|| `${ drive.config!.useSSL ? 'https' : 'http' }://${ drive.config!.endPoint }${ drive.config!.port ? `:${drive.config!.port}` : '' }/${ drive.bucket }`;
 
 		// for original
-		const key = `${drive.prefix}/${genFid()}${ext}`;
+		const key = `${drive.prefix}/${uuid()}${ext}`;
 		const url = `${ baseUrl }/${ key }`;
 
 		// for alts
@@ -84,7 +84,7 @@ async function save(path: string, name: string, info: FileInfo, metadata: IMetad
 		}
 
 		if (alts.thumbnail) {
-			thumbnailKey = `${drive.prefix}/${genFid()}.${alts.thumbnail.ext}`;
+			thumbnailKey = `${drive.prefix}/${uuid()}.${alts.thumbnail.ext}`;
 			thumbnailUrl = `${ baseUrl }/${ thumbnailKey }`;
 
 			logger.info(`uploading thumbnail: ${thumbnailKey}`);
@@ -122,7 +122,7 @@ async function save(path: string, name: string, info: FileInfo, metadata: IMetad
 		return file;
 	} else if (drive.storage == 'fs') {
 
-		const key = `${genFid()}`;
+		const key = `${uuid()}`;
 
 		let thumbnailKey: string | null = null;
 
@@ -133,7 +133,7 @@ async function save(path: string, name: string, info: FileInfo, metadata: IMetad
 		}
 
 		if (alts.thumbnail) {
-			thumbnailKey = `${genFid()}`;
+			thumbnailKey = `${uuid()}`;
 			await InternalStorage.saveFromBufferAsync(thumbnailKey, alts.thumbnail.data);
 		}
 
@@ -168,7 +168,7 @@ async function save(path: string, name: string, info: FileInfo, metadata: IMetad
 		const originalDst = await getDriveFileBucket();
 
 		// web用(Exif削除済み)がある場合はオリジナルにアクセス制限
-		if (alts.webpublic) metadata.accessKey = genFid();
+		if (alts.webpublic) metadata.accessKey = uuid();
 
 		const originalFile = await storeOriginal(originalDst, name, path, info.type.mime, metadata);
 

--- a/src/services/drive/internal-storage.ts
+++ b/src/services/drive/internal-storage.ts
@@ -24,6 +24,7 @@ export class InternalStorage {
 	}
 
 	public static del(key: string) {
+		// eslint-disable-next-line node/prefer-promises/fs
 		fs.unlink(InternalStorage.resolvePath(key), () => {});
 	}
 }


### PR DESCRIPTION
## Summary
現状ファイル名に独自のIDを使用しているが、UUIDを使用したほうが効率がいいためそちらに変更。

今や uuid (v4) は Node.js の crypto.randomUUID へのラッパーであり、こちらの方が速かったりエントロピーキャッシュを持っていたりするので、こちらに統合したほうが良さそうなため。