### PR TITLE
Standalone process

### DIFF
--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -4,6 +4,7 @@ import * as chalk from 'chalk';
 import { format } from 'date-fns';
 import { envOption } from '../env';
 import Log from '../models/log';
+//import { processLabel } from '..';
 
 type Domain = {
 	name: string;
@@ -61,6 +62,7 @@ export default class Logger {
 
 		let log = `${l} ${worker}\t[${domains.join(' ')}]\t${m}`;
 		if (envOption.withLogTime) log = chalk.gray(time) + ' ' + log;
+		//log = `${processLabel} ${process.pid} ` + log;
 
 		console.log(important ? chalk.bold(log) : log);
 


### PR DESCRIPTION
## Summary
Resolve #4156

効いてなかった以下のENVオプションを動くようにする
MK_ONLY_QUEUE queue処理のみ行う
MK_ONLY_SERVER server処理のみ行う

これにより例えば
`MK_DISABLE_CLUSTERING=1 MK_ONLY_QUEUE=1` で起動するといわゆるqueue専用のプロセスが動かせるようになり
`MK_DISABLE_CLUSTERING=1 MK_ONLY_SERVER=1` で起動するといわゆるserver専用のプロセスが動かせるようになる