### PR TITLE
forkbomb DOS mitigation

### DIFF
--- a/src/remote/activitypub/kernel/update/index.ts
+++ b/src/remote/activitypub/kernel/update/index.ts
@@ -26,7 +26,7 @@ export default async (actor: IRemoteUser, activity: IUpdate): Promise<string> =>
 		await updatePerson(actor.uri, resolver, object);
 		return `ok: Person updated`;
 	} else if (getApType(object) === 'Question') {	// isQuestionだとNoteを含んでいる
-		await updateQuestion(object).catch(e => console.log(e));
+		await updateQuestion(object, resolver).catch(e => console.log(e));
 		return `ok: Question updated`;
 	} else {
 		return `skip: Unknown type: ${getApType(object)}`;

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -286,7 +286,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IR
 	});
 	//#endregion
 
-	await updateFeatured(user._id).catch(err => logger.error(err));
+	await updateFeatured(user._id, resolver).catch(err => logger.error(err));
 
 	return user;
 }
@@ -421,7 +421,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: IAct
 		multi: true
 	});
 
-	await updateFeatured(exist._id).catch(err => logger.error(err));
+	await updateFeatured(exist._id, resolver).catch(err => logger.error(err));
 
 	registerOrFetchInstanceDoc(extractDbHost(uri)).then(i => {
 		UpdateInstanceinfo(i);
@@ -536,14 +536,14 @@ export function analyzeAttachments(attachments: IObject | IObject[] | undefined)
 	return { fields, services };
 }
 
-export async function updateFeatured(userId: mongo.ObjectID) {
+export async function updateFeatured(userId: mongo.ObjectID, resolver?: Resolver) {
 	const user = await User.findOne({ _id: userId });
 	if (!isRemoteUser(user)) return;
 	if (!user.featured) return;
 
 	logger.info(`Updating the featured: ${user.uri}`);
 
-	const resolver = new Resolver();
+	if (resolver == null) resolver = new Resolver();
 
 	// Resolve to (Ordered)Collection Object
 	const collection = await resolver.resolveCollection(user.featured);

--- a/src/remote/activitypub/models/question.ts
+++ b/src/remote/activitypub/models/question.ts
@@ -41,7 +41,7 @@ export async function extractPollFromQuestion(source: string | IObject, resolver
  * @param uri URI of AP Question object
  * @returns true if updated
  */
-export async function updateQuestion(value: any) {
+export async function updateQuestion(value: any, resolver?: Resolver) {
 	const uri = typeof value == 'string' ? value : value.id;
 
 	// URIがこのサーバーを指しているならスキップ
@@ -54,7 +54,7 @@ export async function updateQuestion(value: any) {
 	//#endregion
 
 	// resolve new Question object
-	const resolver = new Resolver();
+	if (resolver == null) resolver = new Resolver();
 	const question = await resolver.resolve(value) as IQuestion;
 	apLogger.debug(`fetched question: ${JSON.stringify(question, null, 2)}`);
 

--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -10,9 +10,11 @@ import { isBlockedHost } from '../../services/instance-moderation';
 export default class Resolver {
 	private history: Set<string>;
 	private user?: ILocalUser;
+	private recursionLimit?: number;
 
-	constructor() {
+	constructor(recursionLimit = 100) {
 		this.history = new Set();
+		this.recursionLimit = recursionLimit;
 	}
 
 	public getHistory(): string[] {
@@ -42,6 +44,10 @@ export default class Resolver {
 
 		if (this.history.has(value)) {
 			throw new Error('cannot resolve already resolved one');
+		}
+
+		if (this.recursionLimit && this.history.size > this.recursionLimit) {
+			throw new Error('hit recursion limit');
 		}
 
 		this.history.add(value);


### PR DESCRIPTION
## Summary
Origin?: https://code.vtopia.live/Vtopia/MissV/pulls/8
FoundKey: https://akkoma.dev/FoundKeyGang/FoundKey/pulls/261
misskey-dev: https://github.com/misskey-dev/misskey/pull/9247

APオブジェクトの再帰取得に関連するDoSの脆弱性を緩和します。

Misskeyでは、リモートからユーザーとノートを取得します。
ユーザーにはピン留め投稿一覧といったノートのコレクションを定義する箇所があります。
ユーザー取得/更新時には、ピン留めノート一覧も取得します。
ピン留めノートを取得する際に別のユーザーが参照されていた場合はそれも再帰取得します。

ここで悪意のあるサーバーが、動的にランダムなユーザーとノートを取得無限に生成するようにした場合
取得するMisskeyでは、永遠に再帰取得させられてしまいスタックがあふれたりメモリ使用量の増大が発生してしまいます。
これによりサービス拒否が成立してしまいます。

このプルリクエストでは再帰取得数の制限を加えています。