### PR TITLE
Fix: Hybrid timeline は認証が要る

### DIFF
--- a/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -19,6 +19,8 @@ export const meta = {
 
 	tags: ['notes'],
 
+	requireCredential: true,
+
 	params: {
 		limit: {
 			validator: $.optional.num.range(1, 100),


### PR DESCRIPTION
## Summary
ハイブリッドタイムラインは認証がいるはずなのに不要になるから、クライアントから未認証でリクエストするとサーバー側エラーになる