### PR TITLE
モデレーターの権限を更新できるのは管理者だけ

### DIFF
--- a/src/client/app/admin/views/index.vue
+++ b/src/client/app/admin/views/index.vue
@@ -21,7 +21,7 @@
 			<li><router-link to="/dashboard" active-class="active"><fa icon="home" fixed-width/>{{ $t('dashboard') }}</router-link></li>
 			<li><router-link to="/instance" active-class="active" v-if="$store.getters.isAdminOrModerator"><fa icon="cog" fixed-width/>{{ $t('instance') }}</router-link></li>
 			<li><router-link to="/queue" active-class="active" v-if="$store.getters.isAdminOrModerator"><fa :icon="faTasks" fixed-width/>{{ $t('queue') }}</router-link></li>
-			<li><router-link to="/moderators" active-class="active" v-if="$store.getters.isAdminOrModerator"><fa :icon="faHeadset" fixed-width/>{{ $t('moderators') }}</router-link></li>
+			<li><router-link to="/moderators" active-class="active" v-if="$store.getters.isAdmin"><fa :icon="faHeadset" fixed-width/>{{ $t('moderators') }}</router-link></li>
 			<li><router-link to="/users" active-class="active" v-if="$store.getters.isAdminOrModerator"><fa icon="users" fixed-width/>{{ $t('users') }}</router-link></li>
 			<li><router-link to="/drive" active-class="active" v-if="$store.getters.isAdminOrModerator"><fa icon="cloud" fixed-width/>{{ $t('@.drive') }}</router-link></li>
 			<li><router-link to="/federation" active-class="active"><fa :icon="faGlobe" fixed-width/>{{ $t('federation') }}</router-link></li>

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -112,6 +112,7 @@ export default (os: MiOS) => new Vuex.Store({
 	getters: {
 		isSignedIn: state => state.i != null,
 		isAdminOrModerator: state => state.i && (state.i.isAdmin || state.i.isModerator),
+		isAdmin: state => state.i && state.i.isAdmin,
 	},
 
 	mutations: {


### PR DESCRIPTION
## Summary
モデレーターの権限を更新できるのは管理者だけなので、モデレータがログインしてるなら管理画面にモデレータ編集メニューは表示しない
