### PR TITLE
ユーザーメニューのできない操作は表示しない

### DIFF
--- a/src/client/app/common/views/components/user-menu.vue
+++ b/src/client/app/common/views/components/user-menu.vue
@@ -25,7 +25,7 @@ export default Vue.extend({
 				this.$post({ mention: this.user });
 			}
 		}] as any;
-		
+
 		// ログインユーザー
 		if (this.$store.getters.isSignedIn && this.$store.state.i.id != this.user.id) {
 			menu = menu.concat([
@@ -72,7 +72,7 @@ export default Vue.extend({
 				text: this.user.isSilenced ? this.$t('unsilence') : this.$t('silence'),
 				action: this.toggleSilence
 			}]);
-			if ((!this.user.isAdmin && !this.user.isModerator) || (this.user.isAdmin && this.user.isModerator && this.user.isSuspended)) {
+			if ((!this.user.isAdmin && !this.user.isModerator) || ((this.user.isAdmin || this.user.isModerator) && this.user.isSuspended)) {
 				menu = menu.concat({
 					icon: faSnowflake,
 					text: this.user.isSuspended ? this.$t('unsuspend') : this.$t('suspend'),
@@ -95,7 +95,7 @@ export default Vue.extend({
 
 		startTalk() {
 			if (this.$root.isMobile) {
-				this.$router.push(`/i/messaging/${getAcct(this.user)}`); 
+				this.$router.push(`/i/messaging/${getAcct(this.user)}`);
 			} else {
 				import('../../../desktop/views/components/messaging-room-window.vue').then(m => this.$root.new(m.default, {
 					user: this.user

--- a/src/client/app/common/views/components/user-menu.vue
+++ b/src/client/app/common/views/components/user-menu.vue
@@ -54,14 +54,15 @@ export default Vue.extend({
 					icon: 'ban',
 					text: this.user.isBlocking ? this.$t('unblock') : this.$t('block'),
 					action: this.toggleBlock
-				},
-				null,
-				{
+				}
+			]);
+			if (!this.user.isAdmin) {
+				menu = menu.concat([null,{
 					icon: faExclamationCircle,
 					text: this.$t('report-abuse'),
 					action: this.reportAbuse
-				}
-			]);
+				}]);
+			}
 		}
 
 		// Admin or Moderator

--- a/src/client/app/common/views/components/user-menu.vue
+++ b/src/client/app/common/views/components/user-menu.vue
@@ -70,11 +70,14 @@ export default Vue.extend({
 				icon: faMicrophoneSlash,
 				text: this.user.isSilenced ? this.$t('unsilence') : this.$t('silence'),
 				action: this.toggleSilence
-			}, {
-				icon: faSnowflake,
-				text: this.user.isSuspended ? this.$t('unsuspend') : this.$t('suspend'),
-				action: this.toggleSuspend
 			}]);
+			if ((!this.user.isAdmin && !this.user.isModerator) || (this.user.isAdmin && this.user.isModerator && this.user.isSuspended)) {
+				menu = menu.concat({
+					icon: faSnowflake,
+					text: this.user.isSuspended ? this.$t('unsuspend') : this.$t('suspend'),
+					action: this.toggleSuspend
+				});
+			}
 		}
 
 		return {


### PR DESCRIPTION
## Summary
ユーザーメニューで不可能な操作はそもそも表示しないようにする

・管理者を通報することはできない
・管理者かモデレータを凍結することはできない（凍結解除することはできる）