### PR TITLE
Tune image detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"insert-text-at-cursor": "0.3.0",
 		"ioredis": "4.28.5",
 		"ip-cidr": "3.0.11",
-		"is-svg": "4.3.2",
 		"js-yaml": "4.1.0",
 		"jschardet": "3.0.0",
 		"jsdom": "20.0.3",

--- a/src/misc/detect-url-mime.ts
+++ b/src/misc/detect-url-mime.ts
@@ -1,13 +1,13 @@
 import { createTemp } from './create-temp';
 import { downloadUrl } from './download-url';
-import { detectType, calcHash } from './get-file-info';
+import { detectTypeWithCheck, calcHash } from './get-file-info';
 
 export async function detectUrlMime(url: string) {
 	const [path, cleanup] = await createTemp();
 
 	try {
 		await downloadUrl(url, path);
-		const { mime } = await detectType(path);
+		const { mime } = await detectTypeWithCheck(path);
 		const md5 = await calcHash(path);
 		return { mime, md5 };
 	} finally {

--- a/src/misc/get-file-info.ts
+++ b/src/misc/get-file-info.ts
@@ -3,7 +3,6 @@ import * as crypto from 'crypto';
 import * as stream from 'stream';
 import * as util from 'util';
 import * as FileType from 'file-type';
-import isSvg from 'is-svg';
 import * as probeImageSize from 'probe-image-size';
 import * as FFmpeg from 'fluent-ffmpeg';
 
@@ -96,23 +95,22 @@ const pipeline = util.promisify(stream.pipeline);
 export type FileInfo = {
 	size: number;
 	md5: string;
-	type: {
-		mime: string;
-		ext: string | null;
-	};
+	type: Type;
 	width?: number;
 	height?: number;
 	warnings: string[];
 };
 
+type Type = {
+	mime: string;
+	ext: string | null;
+	width?: number;
+	height?: number;
+}
+
 const TYPE_OCTET_STREAM = {
 	mime: 'application/octet-stream',
 	ext: null
-};
-
-const TYPE_SVG = {
-	mime: 'image/svg+xml',
-	ext: 'svg'
 };
 
 const TYPE_MP4 = {
@@ -143,69 +141,52 @@ export async function getFileInfo(path: string): Promise<FileInfo> {
 	};
 }
 
-/**
- * Detect MIME Type and extension
- */
-export async function detectType(path: string) {
+export async function detectTypeWithCheck(path: string): Promise<Type> {
 	// Check 0 byte
 	const fileSize = await getFileSize(path);
 	if (fileSize === 0) {
 		return TYPE_OCTET_STREAM;
 	}
 
-	const type = await FileType.fromFile(path);
-
-	if (type) {
-		// XMLはSVGかもしれない
-		if (type.mime === 'application/xml' && await checkSvg(path)) {
-			return TYPE_SVG;
+	// 画像か判定＆サイズ取得
+	const img = await detectImageSize(path);
+	if (img) {
+		// 画像だが検出対象でなければoctet-stream
+		if (!FILE_TYPE_DETECTS.includes(img.mime)) {
+			return TYPE_OCTET_STREAM;
 		}
 
+		// 画像だがサイズが制限を超えていたらoctet-stream
+		if (img.width > 16383 || img.height > 16383) {
+			return TYPE_OCTET_STREAM;
+		}
+
+		// 画像確定
 		return {
-			mime: type.mime,
-			ext: type.ext
+			mime: img.mime,
+			ext: img.ext,
+			width: img.width,
+			height: img.height,
 		};
 	}
 
-	// 種類が不明でもSVGかもしれない
-	if (await checkSvg(path)) {
-		return TYPE_SVG;
+	// file-typeで認識
+	const ft = await FileType.fromFile(path)
+
+	// 認識できなければoctet-stream
+	if (!ft) {
+		return TYPE_OCTET_STREAM;
 	}
 
-	// それでも種類が不明なら application/octet-stream にする
-	return TYPE_OCTET_STREAM;
-}
-
-export async function detectTypeWithCheck(path: string) {
-	let type = await detectType(path);
-
-	// check type
-	if (!FILE_TYPE_DETECTS.includes(type.mime)) {
-		type = TYPE_OCTET_STREAM;
+	// 検出対象でなければoctet-stream
+	if (!FILE_TYPE_DETECTS.includes(ft.mime)) {
+		return TYPE_OCTET_STREAM;
 	}
 
-	// image dimensions
-	let width: number | undefined;
-	let height: number | undefined;
-
-	if (type.mime.startsWith('image/')) {
-		const imageSize = await detectImageSize(path).catch(e => {
-			return undefined;
-		});
-
-		// うまく判定できない画像は octet-stream にする
-		if (!imageSize) {
-			type = TYPE_OCTET_STREAM;
-		} else if (imageSize.wUnits === 'px') {
-			width = imageSize.width;
-			height = imageSize.height;
-
-			// 制限を超えている画像は octet-stream にする
-			if (imageSize.width > 16383 || imageSize.height > 16383) {
-				type = TYPE_OCTET_STREAM;
-			}
-		}
-	}
+	let type = {
+		mime: ft.mime as string,
+		ext: ft.ext as string,
+	};
 
 	// quicktime/m4v/m4a だけど h264 と aac で構成されているのは、実際はSafari以外でも再生できちゃうのでmp4扱いにしてしまう
 	if (type.mime === 'video/quicktime' || type.mime === 'video/x-m4v' || type.mime === 'audio/x-m4a') {
@@ -227,25 +208,7 @@ export async function detectTypeWithCheck(path: string) {
 		}
 	}
 
-	return {
-		mime: type.mime,
-		ext: type.ext,
-		width,
-		height,
-	};
-}
-
-/**
- * Check the file is SVG or not
- */
-export async function checkSvg(path: string) {
-	try {
-		const size = await getFileSize(path);
-		if (size > 1 * 1024 * 1024) return false;
-		return isSvg(await fs.promises.readFile(path));
-	} catch {
-		return false;
-	}
+	return type;
 }
 
 /**
@@ -268,16 +231,23 @@ export async function calcHash(path: string): Promise<string> {
 /**
  * Detect dimensions of image
  */
-async function detectImageSize(path: string): Promise<{
-	width: number;
-	height: number;
-	wUnits: string;
-	hUnits: string;
-}> {
+async function detectImageSize(path: string) {
 	const readable = fs.createReadStream(path);
-	const imageSize = await probeImageSize(readable);
+	const probed = await probeImageSize(readable).catch(() => undefined);
 	readable.destroy();
-	return imageSize;
+
+	if (probed) {
+		return {
+			mime: probed.mime,
+			ext: probed.type,
+			width: probed.width,
+			height: probed.height,
+			wUnits: probed.wUnits,
+			hUnits: probed.hUnits,
+		}
+	} else {
+		return undefined;
+	}
 }
 
 export async function getVideoProps(path: string): Promise<FFmpeg.FfprobeData> {

--- a/test/get-file-info.ts
+++ b/test/get-file-info.ts
@@ -54,8 +54,8 @@ describe('Get file info', () => {
 			size: 1868,
 			md5: '08189c607bea3b952704676bb3c979e0',
 			type: {
-				mime: 'image/apng',
-				ext: 'apng'
+				mime: 'image/png',
+				ext: 'png'
 			},
 			width: 256,
 			height: 256,
@@ -138,8 +138,8 @@ describe('Get file info', () => {
 				mime: 'application/octet-stream',
 				ext: null
 			},
-			width: 25000,
-			height: 25000,
+			width: undefined,
+			height: undefined,
 		});
 	}));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,13 +3671,6 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-xml-parser@^3.19.0:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz#152a1d51d445380f7046b304672dd55d15c9e736"
-  integrity sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==
-  dependencies:
-    strnum "^1.0.4"
-
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -4989,13 +4982,6 @@ is-string@^1.0.5, is-string@^1.0.7:
   integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
   dependencies:
     has-tostringtag "^1.0.0"
-
-is-svg@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.2.tgz#a119e9932e1af53f6be1969d1790d6cc5fd947d3"
-  integrity sha512-mM90duy00JGMyjqIVHu9gNTjywdZV+8qNasX8cm/EEYZ53PHDgajvbBwNVvty5dwSAxLUD3p3bdo+7sR/UMrpw==
-  dependencies:
-    fast-xml-parser "^3.19.0"
 
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
@@ -8369,11 +8355,6 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
-strnum@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
-  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 strtok3@^6.2.4:
   version "6.3.0"


### PR DESCRIPTION
## Summary
ファイルタイム認識を効率よく

画像の場合 file-type => probe-image-size で判定してるけど、probe-image-size で画像判定が出来るので
ほとんどの場合画像だから最初から probe-image-size にかけたほうが速い。
SVG判定にis-svg使わなくてよくなる。

Animation avifがmp4扱いされるのを修正