### PR TITLE
CIがコケるのを修正

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: node cli/diag-environment.js
+    - run: sudo apt-get update -y
     - run: sudo apt-get install -y ffmpeg
     - run: yarn install
     - run: git diff --exit-code yarn.lock


### PR DESCRIPTION
## Summary
少し古いバージョンのRunnerが来ることがあるので、apt-get updateしておいたほうが無難ぽい。