### PR TITLE
CSP未定義のデフォルトを全拒否に

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,10 +58,11 @@ if (config.url.startsWith('https') && !config.disableHsts) {
 	});
 }
 
+// Default Security Headers (各ルートで上書き可)
 app.use(async (ctx, next) => {
 	ctx.set('X-Content-Type-Options', 'nosniff');
 	ctx.set('X-Frame-Options', 'DENY');
-	ctx.set('Content-Security-Policy', `default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'`);
+	ctx.set('Content-Security-Policy', `default-src 'none'`);
 	await next();
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -60,6 +60,8 @@ if (config.url.startsWith('https') && !config.disableHsts) {
 
 app.use(async (ctx, next) => {
 	ctx.set('X-Content-Type-Options', 'nosniff');
+	ctx.set('X-Frame-Options', 'DENY');
+	ctx.set('Content-Security-Policy', `default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'`);
 	await next();
 });
 

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -66,13 +66,6 @@ app.use(views(__dirname + '/views', {
 // Serve favicon
 app.use(favicon(`${client}/assets/favicon.ico`));
 
-// Common request handler
-app.use(async (ctx, next) => {
-	// IFrameの中に入れられないようにする
-	ctx.set('X-Frame-Options', 'DENY');
-	await next();
-});
-
 // Init router
 const router = new Router();
 

--- a/test/fetch-resource.ts
+++ b/test/fetch-resource.ts
@@ -129,7 +129,7 @@ describe('Fetch resource', () => {
 			hideTitleWhenPinned: false,
 			sensitive: false,
 			alignCenter: false,
-			content:[{id:randomUUID(),type:'text',text:'Hello World!'}],
+			content: [ { id: randomUUID(), type: 'text', text: 'Hello World!' } ],
 			variables: [],
 			eyeCatchingImageId :null,
 		}, alice);

--- a/test/fetch-resource.ts
+++ b/test/fetch-resource.ts
@@ -28,6 +28,8 @@ const AP = 'application/activity+json; charset=utf-8';
 const JSON = 'application/json; charset=utf-8';
 const HTML = 'text/html; charset=utf-8';
 
+const CSP_STRICT = `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`;
+
 describe('Fetch resource', () => {
 	let p: childProcess.ChildProcess;
 
@@ -96,7 +98,7 @@ describe('Fetch resource', () => {
 
 		// upload image
 		image = await uploadFile(alice);
-		//console.log('image', image);
+		console.log('image', image);
 
 		// post image
 		alicesPostImage = await post(alice, {
@@ -133,21 +135,21 @@ describe('Fetch resource', () => {
 			const res = await simpleGet('/');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('GET docs', async(async () => {
 			const res = await simpleGet('/docs/ja-JP/about');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('GET api-doc', async(async () => {
 			const res = await simpleGet('/api-doc');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('GET api.json', async(async () => {
@@ -174,26 +176,32 @@ describe('Fetch resource', () => {
 			const res = await simpleGet('/info');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('GET flush', async(async () => {
 			const res = await simpleGet('/flush');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('GET embed', (async () => {
 			const res = await simpleGet(`/notes/${alicesPostVideo.id}/embed`);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
+		}));
+
+		it('GET image', (async () => {
+			const res = await simpleGet(`/files/${image.id}/x.jpg?web`);
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(res.type, 'image/jpeg');
+			assert.strictEqual(res.cspx, `default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'`);
 		}));
 
 		// TODO
 		//router.get('/@:user/pages/:page', async ctx => {
-		// TODO file
 	});
 
 	describe('/@:username', () => {
@@ -213,14 +221,14 @@ describe('Fetch resource', () => {
 			const res = await simpleGet(`/@${alice.username}`, PREFER_HTML);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('Unspecified => HTML', async(async () => {
 			const res = await simpleGet(`/@${alice.username}`, UNSPECIFIED);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 	});
 
@@ -267,14 +275,14 @@ describe('Fetch resource', () => {
 			const res = await simpleGet(`/notes/${alicesPost.id}`, PREFER_HTML);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 
 		it('Unspecified => HTML', async(async () => {
 			const res = await simpleGet(`/notes/${alicesPost.id}`, UNSPECIFIED);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
-			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+			assert.strictEqual(res.cspx, CSP_STRICT);
 		}));
 	});
 

--- a/test/fetch-resource.ts
+++ b/test/fetch-resource.ts
@@ -133,18 +133,21 @@ describe('Fetch resource', () => {
 			const res = await simpleGet('/');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 
 		it('GET docs', async(async () => {
 			const res = await simpleGet('/docs/ja-JP/about');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 
 		it('GET api-doc', async(async () => {
 			const res = await simpleGet('/api-doc');
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 
 		it('GET api.json', async(async () => {
@@ -166,6 +169,31 @@ describe('Fetch resource', () => {
 
 			assert.strictEqual(result.problems.length, 0);
 		}));
+
+		it('GET info', async(async () => {
+			const res = await simpleGet('/info');
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+		}));
+
+		it('GET flush', async(async () => {
+			const res = await simpleGet('/flush');
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+		}));
+
+		it('GET embed', (async () => {
+			const res = await simpleGet(`/notes/${alicesPostVideo.id}/embed`);
+			assert.strictEqual(res.status, 200);
+			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
+		}));
+
+		// TODO
+		//router.get('/@:user/pages/:page', async ctx => {
+		// TODO file
 	});
 
 	describe('/@:username', () => {
@@ -185,12 +213,14 @@ describe('Fetch resource', () => {
 			const res = await simpleGet(`/@${alice.username}`, PREFER_HTML);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 
 		it('Unspecified => HTML', async(async () => {
 			const res = await simpleGet(`/@${alice.username}`, UNSPECIFIED);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 	});
 
@@ -237,12 +267,14 @@ describe('Fetch resource', () => {
 			const res = await simpleGet(`/notes/${alicesPost.id}`, PREFER_HTML);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 
 		it('Unspecified => HTML', async(async () => {
 			const res = await simpleGet(`/notes/${alicesPost.id}`, UNSPECIFIED);
 			assert.strictEqual(res.status, 200);
 			assert.strictEqual(res.type, HTML);
+			assert.strictEqual(res.cspx, `base-uri 'none'; default-src 'none'; script-src 'nonce-X 'strict-dynamic' https:; img-src 'self' https: data: blob:; media-src 'self' https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src 'self' https:; manifest-src 'self'; connect-src 'self' data: blob: ws://misskey.local https://api.rss2json.com; frame-ancestors 'none'`);
 		}));
 	});
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -150,7 +150,7 @@ export const uploadFile = async (user: any, _path?: string): Promise<any> => {
 	return body;
 };
 
-export const simpleGet = async (path: string, accept = '*/*'): Promise<{ status?: number, type?: string, location?: string }> => {
+export const simpleGet = async (path: string, accept = '*/*'): Promise<{ status?: number, type?: string, location?: string, cspx?: unknown }> => {
 	// node-fetchだと3xxを取れない
 	return await new Promise((resolve, reject) => {
 		const req = http.request(`http://localhost:${port}${path}`, {
@@ -161,10 +161,14 @@ export const simpleGet = async (path: string, accept = '*/*'): Promise<{ status?
 			if (res.statusCode! >= 400) {
 				reject(res);
 			} else {
+				let cspx = res.headers['content-security-policy'];
+				if (typeof cspx === 'string') cspx = cspx.replace(/nonce-(\S+)/, 'nonce-X');
+
 				resolve({
 					status: res.statusCode,
 					type: res.headers['content-type'],
 					location: res.headers.location,
+					cspx,
 				});
 			}
 		});


### PR DESCRIPTION
## Summary
Content-Security-Policyなどのセキュリティヘッダのデフォルトを全拒否にして、各ルートで上書きするように。
テストの追加。