### PR TITLE
検索のオプトイン/オプトアウト手段を設ける

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -925,6 +925,7 @@ common/views/components/profile-editor.vue:
   auto-accept-followed: "Automatically approve follows from the people you follow"
   avoid-search-index: "Avoid search engine index"
   isExplorable: "Show in explore"
+  searchableBy: "Allow post search"
   hideFollows-none: "Not hide Following / Followed list"
   hideFollows-follower: "Show Following / Followed list only to followers"
   hideFollows-always: "Always hide Following / Followed list"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -986,6 +986,7 @@ common/views/components/profile-editor.vue:
   auto-accept-followed: "フォローしているユーザーからのフォローを自動承認する"
   avoid-search-index: "検索エンジンによるインデックスを避ける"
   isExplorable: "みつけるに表示する"
+  searchableBy: "投稿検索を許可する"
   hideFollows-none: "フォロー/フォロー一覧を隠さない"
   hideFollows-follower: "フォロー/フォロー一覧はフォロワーにのみ公開する"
   hideFollows-always: "フォロー/フォロー一覧を常に隠す"

--- a/src/client/app/common/views/components/settings/profile.vue
+++ b/src/client/app/common/views/components/settings/profile.vue
@@ -94,6 +94,7 @@
 				<ui-switch v-model="autoAcceptFollowed" :disabled="!isLocked && !refuseFollow && !carefulBot && !carefulRemote && !carefulMassive" @change="save(false)">{{ $t('auto-accept-followed') }}</ui-switch>
 				<ui-switch v-model="avoidSearchIndex" @change="save(false)">{{ $t('avoid-search-index') }}</ui-switch>
 				<ui-switch v-model="isExplorable" @change="save(false)">{{ $t('isExplorable') }}</ui-switch>
+				<ui-switch v-model="searchableBy" @change="save(false)">{{ $t('searchableBy') }}</ui-switch>
 				<ui-select v-model="hideFollows" @input="save(false)">
 					<option value="">{{ $t('hideFollows-none') }}</option>
 					<option value="follower">{{ $t('hideFollows-follower') }}</option>
@@ -183,6 +184,7 @@ export default Vue.extend({
 			autoAcceptFollowed: false,
 			avoidSearchIndex: false,
 			isExplorable: false,
+			searchableBy: true,
 			hideFollows: '',
 			noFederation: false,
 			fieldName0 : null,
@@ -237,6 +239,7 @@ export default Vue.extend({
 		this.autoAcceptFollowed = this.$store.state.i.autoAcceptFollowed;
 		this.avoidSearchIndex = this.$store.state.i.avoidSearchIndex;
 		this.isExplorable = this.$store.state.i.isExplorable;
+		this.searchableBy = this.$store.state.i.searchableBy === 'public';
 		this.hideFollows = this.$store.state.i.hideFollows;
 		this.noFederation = this.$store.state.i.noFederation;
 
@@ -339,6 +342,7 @@ export default Vue.extend({
 				avoidSearchIndex: !!this.avoidSearchIndex,
 				isExplorable: !!this.isExplorable,
 				hideFollows: this.hideFollows || '',
+				searchableBy: this.searchableBy ? 'public' : 'none',
 				fields,
 			}).then(i => {
 				this.saving = false;

--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -126,6 +126,7 @@ export type PackedUser = ThinPackedUser & {
 	refuseFollow?: boolean;
 	autoAcceptFollowed?: boolean;
 	isExplorable?: boolean;
+	searchableBy?: string;
 	hideFollows?: string;
 	wallpaperId?: string | null;
 	wallpaperUrl?: string | null;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -141,7 +141,7 @@ type IUserBase = {
 	 */
 	isExplorable?: boolean;
 
-	searchableBy?: 'public' | 'follower' | 'reacted' | null;
+	searchableBy?: 'public' | 'none' | null;
 
 	/**
 	 * このアカウントに届いているフォローリクエストの数

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -543,6 +543,7 @@ export async function pack(
 			refuseFollow: !!db.refuseFollow,
 			autoAcceptFollowed: !!db.autoAcceptFollowed,
 			isExplorable: !!db.isExplorable,
+			searchableBy: db.searchableBy || 'public',
 			hideFollows: db.hideFollows || '',
 
 			wallpaperId: toOidStringOrNull(db.wallpaperId),

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -141,6 +141,8 @@ type IUserBase = {
 	 */
 	isExplorable?: boolean;
 
+	searchableBy?: 'public' | 'follower' | 'reacted' | null;
+
 	/**
 	 * このアカウントに届いているフォローリクエストの数
 	 */

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -625,8 +625,8 @@ function parseSearchableBy(actor: IActor) {
 	if (actor.searchableBy == null) return null;
 	const searchableBy = toArray(actor.searchableBy);
 	if (searchableBy.includes('https://www.w3.org/ns/activitystreams#Public')) return 'public';
-	if (searchableBy.includes(getApId(actor.followers))) return 'follower';
-	return 'reaction';
+	if (searchableBy.includes(getApId(actor.followers))) return 'none';
+	return 'none';
 }
 
 export const exportedForTesting = {

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -161,6 +161,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IR
 			name: person.name ? truncate(person.name, MAX_NAME_LENGTH) : person.name,
 			isLocked: person.manuallyApprovesFollowers,
 			isExplorable: !!person.discoverable,
+			searchableBy: parseSearchableBy(person),
 			username: person.preferredUsername,
 			usernameLower: person.preferredUsername.toLowerCase(),
 			host,
@@ -384,6 +385,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: IAct
 		isCat: (person as any).isCat === true,
 		isLocked: person.manuallyApprovesFollowers,
 		isExplorable: !!person.discoverable,
+		searchableBy: parseSearchableBy(person),
 		publicKey: person.publicKey ? {
 			id: person.publicKey.id,
 			publicKeyPem: person.publicKey.publicKeyPem
@@ -618,3 +620,15 @@ export async function fetchOutbox(user: IUser) {
 		}
 	}
 }
+
+function parseSearchableBy(actor: IActor) {
+	if (actor.searchableBy == null) return null;
+	const searchableBy = toArray(actor.searchableBy);
+	if (searchableBy.includes('https://www.w3.org/ns/activitystreams#Public')) return 'public';
+	if (searchableBy.includes(getApId(actor.followers))) return 'follower';
+	return 'reaction';
+}
+
+export const exportedForTesting = {
+	parseSearchableBy,
+};

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -41,6 +41,7 @@ export const renderActivity = (x: any): IActivity | null => {
 				// Fedibird
 				fedibird: 'http://fedibird.com/ns#',
 				quoteUri: 'fedibird:quoteUri',
+				searchableBy: { '@id': 'fedibird:searchableBy', '@type': '@id' },
 			}
 		]
 	}, x);

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -107,6 +107,7 @@ export default async (user: ILocalUser) => {
 		tag,
 		manuallyApprovesFollowers: user.isLocked || user.carefulRemote,
 		discoverable: !!user.isExplorable,
+		searchableBy: user.searchableBy === 'none' ? [] : ['https://www.w3.org/ns/activitystreams#Public'],
 		publicKey: renderKey(user, `#main-key`),
 		isCat: user.isCat,
 		attachment: attachment.length ? attachment : undefined,

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -228,6 +228,7 @@ export interface IActor extends IObject {
 	preferredUsername: string;
 	manuallyApprovesFollowers?: boolean;
 	discoverable?: boolean;
+	searchableBy?: string[] | string;
 	inbox: string;
 	sharedInbox?: string;
 	publicKey?: {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -146,6 +146,13 @@ export const meta = {
 			}
 		},
 
+		searchableBy: {
+			validator: $.optional.nullable.str.or(['public', 'none']),
+			desc: {
+				'ja-JP': 'searchableBy'
+			}
+		},
+
 		hideFollows: {
 			validator: $.optional.nullable.str.or(['', 'follower', 'always']),
 			desc: {
@@ -283,6 +290,7 @@ export default define(meta, async (ps, user, app) => {
 	if (typeof ps.autoAcceptFollowed == 'boolean') updates.autoAcceptFollowed = ps.autoAcceptFollowed;
 	if (typeof ps.avoidSearchIndex == 'boolean') updates.avoidSearchIndex = ps.avoidSearchIndex;
 	if (typeof ps.isExplorable == 'boolean') updates.isExplorable = ps.isExplorable;
+	if (ps.searchableBy !== undefined) updates.searchableBy = ps.searchableBy;
 	if (ps.hideFollows !== undefined) updates.hideFollows = ps.hideFollows;
 	if (typeof ps.noFederation == 'boolean') updates.noFederation = ps.noFederation;
 	if (typeof ps.isCat == 'boolean') updates.isCat = ps.isCat;

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -434,7 +434,7 @@ export default async (user: IUser, data: Option, silent = false) => {
 		}
 
 		// Register to search database
-		index(note);
+		index(note, user);
 
 		if (isLocalUser(user) && note.poll && note.poll.expiresAt) {
 			createNotifyPollFinishedJob(note, user, note.poll.expiresAt);
@@ -555,8 +555,9 @@ async function insertNote(user: IUser, data: Option, tags: string[], emojis: str
 	}
 }
 
-function index(note: INote) {
+function index(note: INote, user: IUser) {
 	if (note.visibility !== 'public') return;
+	if (user.searchableBy != null && user.searchableBy !== 'public') return;
 
 	if (config.mecabSearch) {
 		// for search

--- a/test/activitypub.ts
+++ b/test/activitypub.ts
@@ -323,7 +323,7 @@ describe('ActivityPub', () => {
 				type: 'Person', preferredUsername: 'a', inbox: 'b', outbox: 'c', '@context': 'd',
 				followers: 'https://example.com/users/a/followers',
 				searchableBy: [ 'https://example.com/users/a/followers' ],
-			}), 'follower');
+			}), 'none');
 		});
 
 		it('parseSearchableBy - reaction', () => {
@@ -331,7 +331,7 @@ describe('ActivityPub', () => {
 				type: 'Person', preferredUsername: 'a', inbox: 'b', outbox: 'c', '@context': 'd',
 				followers: 'https://example.com/users/a/followers',
 				searchableBy: [],
-			}), 'reaction');
+			}), 'none');
 		});
 
 		it('parseSearchableBy - undefined', () => {

--- a/test/activitypub.ts
+++ b/test/activitypub.ts
@@ -17,7 +17,7 @@ import * as assert from 'assert';
 import rndstr from 'rndstr';
 import Resolver from '../src/remote/activitypub/resolver';
 import { IObject } from '../src/remote/activitypub/type';
-import { createPerson } from '../src/remote/activitypub/models/person';
+import { createPerson, exportedForTesting } from '../src/remote/activitypub/models/person';
 import { createNote } from '../src/remote/activitypub/models/note';
 import { tryProcessInbox } from '../src/queue/processors/inbox';
 import { LdSignature } from '../src/remote/activitypub/misc/ld-signature';
@@ -304,6 +304,41 @@ describe('ActivityPub', () => {
 			await assert.rejects(ldSignature.verifyRsaSignature2017(signed, ec1.publicKey), {
 				message: 'publicKey is not rsa'
 			});
+		});
+	});
+
+	describe('parseSearchableBy', () => {
+		const parseSearchableBy = exportedForTesting.parseSearchableBy;
+
+		it('parseSearchableBy - public', () => {
+			assert.strictEqual(parseSearchableBy({
+				type: 'Person', preferredUsername: 'a', inbox: 'b', outbox: 'c', '@context': 'd',
+				followers: 'https://example.com/users/a/followers',
+				searchableBy: [ 'https://www.w3.org/ns/activitystreams#Public' ],
+			}), 'public');
+		});
+
+		it('parseSearchableBy - follower', () => {
+			assert.strictEqual(parseSearchableBy({
+				type: 'Person', preferredUsername: 'a', inbox: 'b', outbox: 'c', '@context': 'd',
+				followers: 'https://example.com/users/a/followers',
+				searchableBy: [ 'https://example.com/users/a/followers' ],
+			}), 'follower');
+		});
+
+		it('parseSearchableBy - reaction', () => {
+			assert.strictEqual(parseSearchableBy({
+				type: 'Person', preferredUsername: 'a', inbox: 'b', outbox: 'c', '@context': 'd',
+				followers: 'https://example.com/users/a/followers',
+				searchableBy: [],
+			}), 'reaction');
+		});
+
+		it('parseSearchableBy - undefined', () => {
+			assert.strictEqual(parseSearchableBy({
+				type: 'Person', preferredUsername: 'a', inbox: 'b', outbox: 'c', '@context': 'd',
+				followers: 'https://example.com/users/a/followers',
+			}), null);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Resolve #4564

ユーザー設定で投稿検索を許可するか設定できるように

Fedibirdからの投稿検索設定を尊重するように
ただし、公開以外 (フォロワー限定/リアクション限定) は未対応なため一律しない扱いになります。

リモートへはFedibird仕様のリアクション限定扱いになります。