### PR TITLE
Discordのユーザー名形式の変更に対応

### DIFF
--- a/src/client/app/common/views/components/integrations.vue
+++ b/src/client/app/common/views/components/integrations.vue
@@ -2,7 +2,7 @@
 <div class="nbogcrmo" :v-if="user.twitter || user.github || user.discord">
 	<x-integration v-if="user.twitter" service="twitter" :url="`https://twitter.com/${user.twitter.screenName}`" :text="user.twitter.screenName" :icon="['fab', 'twitter']"/>
 	<x-integration v-if="user.github" service="github" :url="`https://github.com/${user.github.login}`" :text="user.github.login" :icon="['fab', 'github']"/>
-	<x-integration v-if="user.discord" service="discord" :url="`https://discord.com/users/${user.discord.id}`" :text="`${user.discord.username}#${user.discord.discriminator}`" :icon="['fab', 'discord']"/>
+	<x-integration v-if="user.discord" service="discord" :url="`https://discord.com/users/${user.discord.id}`" :text="discordName" :icon="['fab', 'discord']"/>
 </div>
 </template>
 
@@ -14,7 +14,14 @@ export default Vue.extend({
 	components: {
 		XIntegration
 	},
-	props: ['user']
+	props: ['user'],
+	computed: {
+		discordName(): string {
+			return this.user.discord.global_name
+				? `${this.user.discord.username}`
+				: `${this.user.discord.username}#${this.user.discord.discriminator}`;
+		},
+	},
 });
 </script>
 

--- a/src/client/app/common/views/components/settings/integration.vue
+++ b/src/client/app/common/views/components/settings/integration.vue
@@ -11,7 +11,7 @@
 
 	<section v-if="enableDiscordIntegration">
 		<header>Discord</header>
-		<p v-if="$store.state.i.discord">{{ $t('connected-to') }}: <a :href="`https://discord.com/users/${$store.state.i.discord.id}`" rel="nofollow noopener" target="_blank">@{{ $store.state.i.discord.username }}#{{ $store.state.i.discord.discriminator }}</a></p>
+		<p v-if="$store.state.i.discord">{{ $t('connected-to') }}: <a :href="`https://discord.com/users/${$store.state.i.discord.id}`" rel="nofollow noopener" target="_blank">@{{ discordName }}</a></p>
 		<ui-button v-if="$store.state.i.discord" @click="disconnectDiscord">{{ $t('disconnect') }}</ui-button>
 		<ui-button v-else @click="connectDiscord">{{ $t('connect') }}</ui-button>
 	</section>
@@ -68,6 +68,14 @@ export default Vue.extend({
 		}, {
 			deep: true
 		});
+	},
+
+	computed: {
+		discordName(): string {
+			return this.$store.state.i.discord.global_name
+				? `${this.$store.state.i.discord.username}`
+				: `${this.$store.state.i.discord.username}#${this.$store.state.i.discord.discriminator}`;
+		},
 	},
 
 	methods: {

--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -112,7 +112,6 @@ export type PackedUser = ThinPackedUser & {
 	};
 	discord?: {
 		id: string;
-		name: string;
 		global_name?: string;
 		username: string;
 		discriminator: string;

--- a/src/models/packed-schemas.ts
+++ b/src/models/packed-schemas.ts
@@ -112,6 +112,8 @@ export type PackedUser = ThinPackedUser & {
 	};
 	discord?: {
 		id: string;
+		name: string;
+		global_name?: string;
 		username: string;
 		discriminator: string;
 	};

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -184,6 +184,7 @@ export interface ILocalUser extends IUserBase {
 		refreshToken: string;
 		expiresDate: number;
 		id: string;
+		global_name?: string;
 		username: string;
 		discriminator: string;
 	};
@@ -519,16 +520,17 @@ export async function pack(
 				twitter: db.twitter ? {
 					screenName: db.twitter?.screenName,
 					userId: db.twitter?.userId
-				} : undefined,
+				} : null,
 				github: db.github ? {
 					id: db.github?.id,
 					login: db.github?.login
-				} : undefined,
+				} : null,
 				discord: db.discord ? {
 					id: db.discord?.id,
+					global_name: db.discord?.global_name,
 					username: db.discord?.username,
 					discriminator: db.discord?.discriminator,
-				} : undefined,
+				} : null,
 			}: {}),
 		} : {}),
 

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -169,7 +169,7 @@ router.get('/dc/cb', async ctx => {
 					});
 				}));
 
-		const { id, username, discriminator } = await getJson('https://discord.com/api/users/@me', '*/*', 10 * 1000, {
+		const { id, global_name, username, discriminator } = await getJson('https://discord.com/api/users/@me', '*/*', 10 * 1000, {
 			'Authorization': `Bearer ${accessToken}`,
 		});
 
@@ -198,6 +198,7 @@ router.get('/dc/cb', async ctx => {
 					accessToken,
 					refreshToken,
 					expiresDate,
+					global_name,
 					username,
 					discriminator
 				}
@@ -244,7 +245,7 @@ router.get('/dc/cb', async ctx => {
 						});
 				}));
 
-		const { id, username, discriminator } = await getJson('https://discord.com/api/users/@me', '*/*', 10 * 1000, {
+		const { id, global_name, username, discriminator } = await getJson('https://discord.com/api/users/@me', '*/*', 10 * 1000, {
 			'Authorization': `Bearer ${accessToken}`,
 		});
 		if (!id || !username || !discriminator) {
@@ -262,6 +263,7 @@ router.get('/dc/cb', async ctx => {
 					refreshToken,
 					expiresDate,
 					id,
+					global_name,
 					username,
 					discriminator
 				}


### PR DESCRIPTION
## Summary
Resolve #4643
`#`なしユーザー名で表示できるように、反映は再連携が必要
APはいい案がないので変更なし `username#0` になる
表示名は取得してAPIにも出すがあまり使い道がないので表示されない

連携を解除しても連携画面が更新されないのを修正