### PR TITLE
Tune console color

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ if (process.env.UV_THREADPOOL_SIZE == null) {
 
 import * as os from 'os';
 import * as cluster from 'cluster';
-import * as chalk from 'chalk';
 import Xev from 'xev';
 
 import Logger from './services/logger';
@@ -121,17 +120,20 @@ function greet(config: Config) {
 	if (!envOption.quiet && process.env.NODE_ENV !== 'test') {
 		//#region Meisskey logo
 		const v = `v${config.version}`;
-		console.log(chalk.red(' '));
-		console.log(chalk.red(' • ▌ ▄ ·. ▄▄▄ .▪  .▄▄ · .▄▄ · ▄ •▄ ▄▄▄ . ▄· ▄▌'));
-		console.log(chalk.red(' ·██ ▐███▪▀▄.▀·██ ▐█ ▀. ▐█ ▀. █▌▄▌▪▀▄.▀·▐█▪██▌'));
-		console.log(chalk.red(` ▐█ ▌▐▌▐█·▐▀▀▪▄▐█·▄▀▀▀█▄▄▀▀▀█▄▐▀▀▄·▐▀▀▪▄▐█▌▐█▪`));
-		console.log(chalk.red(' ██ ██▌▐█▌▐█▄▄▌▐█▌▐█▄▪▐█▐█▄▪▐█▐█.█▌▐█▄▄▌ ▐█▀·.'));
-		console.log(chalk.red(' ▀▀  █▪▀▀▀ ▀▀▀ ▀▀▀ ▀▀▀▀  ▀▀▀▀ ·▀  ▀ ▀▀▀   ▀ • '));
-		console.log(' ' + chalk.redBright(v));
+
+		console.log(` 
+ ______        _           _                
+|  ___ \\      (_)         | |               
+| | _ | | ____ _  ___  ___| |  _ ____ _   _ 
+| || || |/ _  ) |/___)/___) | / ) _  ) | | |
+| || || ( (/ /| |___ |___ | |< ( (/ /| |_| |
+|_||_||_|\\____)_(___/(___/|_| \\_)____)\\__  |
+                                     (____/ `);
+		console.log(' ' + v);
 		//#endregion
 
 		console.log('');
-		console.log(chalk`< ${os.hostname()} {gray (PID: ${process.pid.toString()})} >`);
+		console.log(`< ${os.hostname()} (PID: ${process.pid.toString()}) >`);
 	}
 
 	bootLogger.info('Welcome to Meisskey!');

--- a/src/misc/download-url.ts
+++ b/src/misc/download-url.ts
@@ -4,7 +4,6 @@ import * as util from 'util';
 import got, * as Got from 'got';
 import { httpAgent, httpsAgent, StatusError } from './fetch';
 import config from '../config';
-import * as chalk from 'chalk';
 import Logger from '../services/logger';
 import { checkPrivateIp } from './check-private-ip';
 import { checkAllowedUrl } from './check-allowed-url';
@@ -18,7 +17,7 @@ export async function downloadUrl(url: string, path: string) {
 
 	const logger = new Logger('download-url');
 
-	logger.info(`Downloading ${chalk.cyan(url)} ...`);
+	logger.info(`Downloading ${url} ...`);
 
 	const timeout = 30 * 1000;
 	const operationTimeout = 60 * 1000;
@@ -79,5 +78,5 @@ export async function downloadUrl(url: string, path: string) {
 		}
 	}
 
-	logger.succ(`Download finished: ${chalk.cyan(url)}`);
+	logger.succ(`Download finished: ${url}`);
 }

--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -5,7 +5,6 @@ import config from '../config';
 import { createPerson, updatePerson } from './activitypub/models/person';
 import { URL } from 'url';
 import { remoteLogger } from './logger';
-import * as chalk from 'chalk';
 
 const logger = remoteLogger.createSubLogger('resolve-user');
 
@@ -38,7 +37,7 @@ export default async (username: string, _host: string | null, option?: any, resy
 	if (user === null) {
 		const self = await resolveSelf(acctLower);
 
-		logger.succ(`return new remote user: ${chalk.magenta(acctLower)}`);
+		logger.succ(`return new remote user: ${acctLower}`);
 		return await createPerson(self.href);
 	}
 
@@ -92,14 +91,14 @@ export default async (username: string, _host: string | null, option?: any, resy
 };
 
 async function resolveSelf(acctLower: string) {
-	logger.info(`WebFinger for ${chalk.yellow(acctLower)}`);
+	logger.info(`WebFinger for ${acctLower}`);
 	const finger = await webFinger(acctLower).catch(e => {
-		logger.error(`Failed to WebFinger for ${chalk.yellow(acctLower)}: ${ e.statusCode || e.message }`);
+		logger.error(`Failed to WebFinger for ${acctLower}: ${ e.statusCode || e.message }`);
 		throw new Error(`Failed to WebFinger for ${acctLower}: ${ e.statusCode || e.message }`);
 	});
 	const self = finger.links.find(link => link.rel && link.rel.toLowerCase() === 'self');
 	if (!self) {
-		logger.error(`Failed to WebFinger for ${chalk.yellow(acctLower)}: self link not found`);
+		logger.error(`Failed to WebFinger for ${acctLower}: self link not found`);
 		throw new Error('self link not found');
 	}
 	return self;

--- a/src/services/logger.ts
+++ b/src/services/logger.ts
@@ -1,10 +1,12 @@
 import * as cluster from 'cluster';
 import * as os from 'os';
-import * as chalk from 'chalk';
+import * as Chalk from 'chalk';
 import { format } from 'date-fns';
 import { envOption } from '../env';
 import Log from '../models/log';
 //import { processLabel } from '..';
+
+const chalk = new Chalk.Instance(process.env.NODE_ENV === 'production' ? { level: 0 } : {});
 
 type Domain = {
 	name: string;


### PR DESCRIPTION
## Summary
ダウンロードなどでログメッセージ自体にシェルのエスケープシーケンスを入れるのをやめる
productionの場合は、自動判定関係なくコンソールログに色を付けないように
起動ロゴの変更