### PR TITLE
YouTubeの代替えドメイン

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -382,6 +382,7 @@ common:
         cheep: "Cheep"
       useOrthographicCamera: "Use Orthographic Camera"
     nitter: "Alternate domains for Twitter"
+    altYoutube: "Alternate domains for YouTube"
   search: "Search"
   delete: "Delete"
   loading: "Loading"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -397,6 +397,7 @@ common:
         cheep: "最低"
       useOrthographicCamera: "平行投影カメラを使用"
     nitter: "Twitterの代替ドメイン"
+    altYoutube: "YouTubeの代替ドメイン"
 
   search: "検索"
   delete: "削除"

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
 		"stringz": "2.1.0",
 		"stylus": "0.59.0",
 		"stylus-loader": "7.1.3",
-		"summaly": "mei23/summaly#3.8.3",
+		"summaly": "mei23/summaly#3.9.0",
 		"suncalc": "1.9.0",
 		"systeminformation": "5.21.7",
 		"syuilo-password-strength": "0.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,8 +348,8 @@ dependencies:
     specifier: 7.1.3
     version: 7.1.3(stylus@0.59.0)(webpack@5.88.1)
   summaly:
-    specifier: mei23/summaly#3.8.3
-    version: github.com/mei23/summaly/40c5faae6b4e2f2660f6acc28ab97beaeb580433
+    specifier: mei23/summaly#3.9.0
+    version: github.com/mei23/summaly/5b3cdaf8f7f1ff5df851fcfa655a1276896d9bcb
   suncalc:
     specifier: 1.9.0
     version: 1.9.0
@@ -4138,6 +4138,11 @@ packages:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
     dev: false
 
+  /consola@3.2.3:
+    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+    dev: false
+
   /consolidate@0.15.1(lodash@4.17.21)(pug@3.0.2):
     resolution: {integrity: sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==}
     engines: {node: '>= 0.10.0'}
@@ -4978,8 +4983,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /destr@1.2.2:
-    resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
+  /destr@2.0.1:
+    resolution: {integrity: sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==}
     dev: false
 
   /destroy@1.2.0:
@@ -6270,19 +6275,20 @@ packages:
       '@sinclair/typebox': 0.25.23
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
-      h3: 1.6.5
+      h3: 1.8.2
     dev: false
 
-  /h3@1.6.5:
-    resolution: {integrity: sha512-A0r2LCDzeavSfcAbJpMwHXLcSN0H3FpEZtYigbz4IYun0fOE8r6vy3galwubAnmc6gXVob4261zXQsu3sZayzg==}
+  /h3@1.8.2:
+    resolution: {integrity: sha512-1Ca0orJJlCaiFY68BvzQtP2lKLk46kcLAxVM8JgYbtm2cUg6IY7pjpYgWMwUvDO9QI30N5JAukOKoT8KD3Q0PQ==}
     dependencies:
       cookie-es: 1.0.0
       defu: 6.1.2
-      destr: 1.2.2
-      iron-webcrypto: 0.7.0
-      radix3: 1.0.1
-      ufo: 1.1.2
-      uncrypto: 0.1.2
+      destr: 2.0.1
+      iron-webcrypto: 0.10.1
+      radix3: 1.1.0
+      ufo: 1.3.1
+      uncrypto: 0.1.3
+      unenv: 1.7.4
     dev: false
 
   /has-bigints@1.0.2:
@@ -6393,8 +6399,8 @@ packages:
       whatwg-encoding: 2.0.0
     dev: false
 
-  /html-entities@2.3.3:
-    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+  /html-entities@2.4.0:
+    resolution: {integrity: sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==}
     dev: false
 
   /htmlescape@1.1.1:
@@ -6657,8 +6663,8 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
-  /iron-webcrypto@0.7.0:
-    resolution: {integrity: sha512-WkX32iTcwd79ZsWRPP5wq1Jq6XXfPwO783ZiUBY8uMw4/AByx5WvBmxvYGnpVt6AOVJ0F41Qo420r8lIneT9Wg==}
+  /iron-webcrypto@0.10.1:
+    resolution: {integrity: sha512-QGOS8MRMnj/UiOa+aMIgfyHcvkhqNUsUxb1XzskENvbo+rEfp6TOwqd1KPuDzXC4OnGHcMSVxDGRoilqB8ViqA==}
     dev: false
 
   /is-absolute@1.0.0:
@@ -7827,6 +7833,12 @@ packages:
     dependencies:
       mime-db: 1.52.0
 
+  /mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dev: false
+
   /mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -8199,6 +8211,10 @@ packages:
 
   /node-addon-api@6.1.0:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+    dev: false
+
+  /node-fetch-native@1.4.0:
+    resolution: {integrity: sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==}
     dev: false
 
   /node-fetch@2.6.7:
@@ -8639,6 +8655,10 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: false
 
   /peek-readable@4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
@@ -9394,8 +9414,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /radix3@1.0.1:
-    resolution: {integrity: sha512-y+AcwZ3HcUIGc9zGsNVf5+BY/LxL+z+4h4J3/pp8jxSmy1STaCocPS3qrj4tA5ehUSzqtqK+0Aygvz/r/8vy4g==}
+  /radix3@1.1.0:
+    resolution: {integrity: sha512-pNsHDxbGORSvuSScqNJ+3Km6QAVqk8CfsCBIEoDgpqLrkD2f3QM4I7d1ozJJ172OmIcoUcerZaNWqtLkRXTV3A==}
     dev: false
 
   /randombytes@2.1.0:
@@ -10887,19 +10907,19 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: false
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-    dev: false
-
   /typescript@5.1.6:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /ufo@1.1.2:
-    resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
+  /ufo@1.3.1:
+    resolution: {integrity: sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==}
     dev: false
 
   /unbox-primitive@1.0.2:
@@ -10916,8 +10936,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /uncrypto@0.1.2:
-    resolution: {integrity: sha512-kuZwRKV615lEw/Xx3Iz56FKk3nOeOVGaVmw0eg+x4Mne28lCotNFbBhDW7dEBCBKyKbRQiCadEZeNAFPVC5cgw==}
+  /uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
     dev: false
 
   /undertaker-registry@1.0.1:
@@ -10939,6 +10959,16 @@ packages:
       object.defaults: 1.1.0
       object.reduce: 1.0.1
       undertaker-registry: 1.0.1
+    dev: false
+
+  /unenv@1.7.4:
+    resolution: {integrity: sha512-fjYsXYi30It0YCQYqLOcT6fHfMXsBr2hw9XC7ycf8rTG7Xxpe3ZssiqUnD0khrjiZEmkBXWLwm42yCSCH46fMw==}
+    dependencies:
+      consola: 3.2.3
+      defu: 6.1.2
+      mime: 3.0.0
+      node-fetch-native: 1.4.0
+      pathe: 1.1.1
     dev: false
 
   /union-value@1.0.1:
@@ -11792,22 +11822,22 @@ packages:
       sshpk: 1.17.0
     dev: false
 
-  github.com/mei23/summaly/40c5faae6b4e2f2660f6acc28ab97beaeb580433:
-    resolution: {tarball: https://codeload.github.com/mei23/summaly/tar.gz/40c5faae6b4e2f2660f6acc28ab97beaeb580433}
+  github.com/mei23/summaly/5b3cdaf8f7f1ff5df851fcfa655a1276896d9bcb:
+    resolution: {tarball: https://codeload.github.com/mei23/summaly/tar.gz/5b3cdaf8f7f1ff5df851fcfa655a1276896d9bcb}
     name: summaly
-    version: 3.8.3
+    version: 3.9.0
     dependencies:
       cheerio: 1.0.0-rc.12
       escape-regexp: 0.0.1
       got: 11.8.6
-      h3: 1.6.5
+      h3: 1.8.2
       h3-typebox: 0.6.0
-      html-entities: 2.3.3
+      html-entities: 2.4.0
       iconv-lite: 0.6.3
       js-yaml: 4.1.0
       jschardet: 3.0.0
       private-ip: 2.3.4
-      typescript: 5.0.4
+      typescript: 5.2.2
     dev: false
 
   github.com/mei23/twemoji-parser/75831bfddb415cefc1e89ac5232e883daf91a624:

--- a/src/client/app/common/views/components/settings/settings.vue
+++ b/src/client/app/common/views/components/settings/settings.vue
@@ -207,6 +207,9 @@
 				<header>{{ $t('@._settings.nitter') }}</header>
 				<ui-input v-model="nitter" :debounce="true">
 				</ui-input>
+				<header>{{ $t('@._settings.altYoutube') }}</header>
+				<ui-input v-model="altYoutube" :debounce="true">
+				</ui-input>
 			</section>
 
 			<section>
@@ -591,6 +594,14 @@ export default Vue.extend({
 			get() { return this.$store.state.device.nitter; },
 			set(value: string) {
 				this.$store.commit('device/set', { key: 'nitter', value: value.trim() });
+				this.$notify(this.$t('@._settings.saved'));
+			}
+		},
+
+		altYoutube: {
+			get() { return this.$store.state.device.altYoutube; },
+			set(value: string) {
+				this.$store.commit('device/set', { key: 'altYoutube', value: value.trim() });
 				this.$notify(this.$t('@._settings.saved'));
 			}
 		},

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -45,9 +45,6 @@
 		<a v-if="tweetId" :href="`https://${nitter}/${twitterUser}/status/${tweetId}`" rel="nofollow noopener" target="_blank">{{ $t('alternativeLink') }}</a>
 		<a v-else-if="twitterUser" :href="`https://${nitter}/${twitterUser}`" rel="nofollow noopener" target="_blank">{{ $t('alternativeLink') }}</a>
 	</div>
-	<div class="altYoutube" v-if="this.$store.state.device.altYoutube && youtubePath">
-		<a :href="`https://${$store.state.device.altYoutube}${youtubePath}`" rel="nofollow noopener" target="_blank">{{ $t('alternativeLink') }}</a>
-	</div>
 </div>
 </template>
 
@@ -108,8 +105,6 @@ export default Vue.extend({
 			playerEnabled: false,
 			misskeyUrl,
 			nitter: null,
-			youtubePath: null,
-			youtubeId: null,
 		};
 	},
 
@@ -142,21 +137,10 @@ export default Vue.extend({
 
 		// Alt YouTube
 		if (this.$store.state.device.altYoutube) {
-			if (requestUrl.hostname === 'www.youtube.com' || requestUrl.hostname === 'm.youtube.com') {
-				this.youtubePath = `${requestUrl.pathname}${requestUrl.search}`;
-
-				if (requestUrl.pathname === '/watch' && requestUrl.searchParams.get('v')) {
-					this.youtubeId = requestUrl.searchParams.get('v')
-				}
-			} else if (requestUrl.hostname === 'youtu.be') {
-				this.youtubePath = `${requestUrl.pathname}${requestUrl.search}`;
-				this.youtubeId = requestUrl.pathname.replace(/^[/]/, '') || null;
+			if (requestUrl.hostname === 'www.youtube.com' || requestUrl.hostname === 'm.youtube.com' || requestUrl.hostname === 'youtu.be') {
+				const youtubePath = `${requestUrl.pathname}${requestUrl.search}`;
+				requestUrl = new URL(`https://${this.$store.state.device.altYoutube}${youtubePath}`);
 			}
-		}
-
-		// Rewrite preview URL to alts
-		if (this.youtubePath) {
-			requestUrl = new URL(`https://${this.$store.state.device.altYoutube}${this.youtubePath}`);
 		}
 
 		if (requestUrl.hostname === 'music.youtube.com' && requestUrl.pathname.match('^/(?:watch|channel)')) {

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -45,6 +45,9 @@
 		<a v-if="tweetId" :href="`https://${nitter}/${twitterUser}/status/${tweetId}`" rel="nofollow noopener" target="_blank">{{ $t('alternativeLink') }}</a>
 		<a v-else-if="twitterUser" :href="`https://${nitter}/${twitterUser}`" rel="nofollow noopener" target="_blank">{{ $t('alternativeLink') }}</a>
 	</div>
+	<div class="altYoutube" v-if="this.$store.state.device.altYoutube && youtubePath">
+		<a :href="`https://${this.$store.state.device.altYoutube}${youtubePath}`" rel="nofollow noopener" target="_blank">{{ $t('alternativeLink') }}</a>
+	</div>
 </div>
 </template>
 
@@ -105,6 +108,7 @@ export default Vue.extend({
 			playerEnabled: false,
 			misskeyUrl,
 			nitter: null,
+			youtubePath: null,
 		};
 	},
 
@@ -133,6 +137,10 @@ export default Vue.extend({
 			if (mUser) {
 				this.twitterUser = mUser[1];
 			}
+		}
+
+		if (requestUrl.hostname === 'www.youtube.com' || requestUrl.hostname === 'm.youtube.com' || requestUrl.hostname === 'youtu.be') {
+			this.youtubePath = `${requestUrl.pathname}${requestUrl.search}`;
 		}
 
 		if (requestUrl.hostname === 'music.youtube.com' && requestUrl.pathname.match('^/(?:watch|channel)')) {

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -98,6 +98,7 @@ const defaultDeviceSettings = Object.assign({
 	appType: 'auto',
 	emojiSkinTone: null,
 	nitter: '',
+	altYoutube: '',
 }, mods.defaultDeviceSettings || {});
 
 export default (os: MiOS) => new Vuex.Store({


### PR DESCRIPTION
## Summary
YouTubeの代替えドメイン Resolve #4727

設定すると、URLプレビューと埋め込みプレイヤーごと代替えURLになる

ついでにURLプレビューでplayerが相対URLの場合にうまくいかないのを修正