### PR TITLE
投稿の諸々の制約の修正

### DIFF
--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -5,7 +5,7 @@ import { length } from 'stringz';
 import Note, { INote, isValidCw, pack } from '../../../../models/note';
 import User, { IUser } from '../../../../models/user';
 import DriveFile, { IDriveFile } from '../../../../models/drive-file';
-import create from '../../../../services/note/create';
+import create, { NoteError } from '../../../../services/note/create';
 import define from '../../define';
 import fetchMeta from '../../../../misc/fetch-meta';
 import { ApiError } from '../../error';
@@ -236,6 +236,12 @@ export const meta = {
 			id: '6f57e42b-c348-439b-bc45-993995cc515a'
 		},
 
+		noteError: {
+			message: 'Note error.',
+			code: 'NOTE_ERROR',
+			id: '98ca3924-0b21-4690-ab03-9059fba4453d'
+		},
+
 		cannotCreateAlreadyExpiredPoll: {
 			message: 'Poll is already expired.',
 			code: 'CANNOT_CREATE_ALREADY_EXPIRED_POLL',
@@ -273,10 +279,6 @@ export default define(meta, async (ps, user, app) => {
 		files = removeNull(_files);
 	}
 
-	const isPureRenote = (target: INote) => {
-		return target.renoteId && target.text == null && (target.fileIds == null || target.fileIds.length === 0) && target.poll == null;
-	};
-
 	// Renote/引用
 	let renote: INote | null | undefined = null;
 	if (ps.renoteId != null) {
@@ -286,10 +288,6 @@ export default define(meta, async (ps, user, app) => {
 
 		if (renote == null) {
 			throw new ApiError(meta.errors.noSuchRenoteTarget);
-		}
-
-		if (isPureRenote(renote)) {
-			throw new ApiError(meta.errors.cannotReRenote);
 		}
 	}
 
@@ -303,11 +301,6 @@ export default define(meta, async (ps, user, app) => {
 
 		if (reply == null) {
 			throw new ApiError(meta.errors.noSuchReplyTarget);
-		}
-
-		// 返信対象が引用でないRenoteだったらエラー
-		if (isPureRenote(reply)) {
-			throw new ApiError(meta.errors.cannotReplyToPureRenote);
 		}
 	}
 
@@ -337,32 +330,41 @@ export default define(meta, async (ps, user, app) => {
 	}
 
 	// 投稿を作成
-	const note = await create(user, {
-		preview: ps.preview,
-		createdAt: new Date(),
-		files: files,
-		poll: ps.poll ? {
-			choices: ps.poll.choices,
-			multiple: ps.poll.multiple || false,
-			expiresAt: ps.poll.expiresAt ? new Date(ps.poll.expiresAt) : null
-		} : undefined,
-		text: ps.text,
-		reply,
-		renote,
-		cw: ps.cw,
-		app,
-		viaMobile: ps.viaMobile,
-		localOnly: ps.localOnly,
-		copyOnce: ps.copyOnce,
-		visibility: ps.visibility,
-		visibleUsers,
-		apMentions: ps.noExtractMentions ? [] : undefined,
-		apHashtags: ps.noExtractHashtags ? [] : undefined,
-		apEmojis: ps.noExtractEmojis ? [] : undefined,
-		geo: ps.geo
-	});
+	try {
+		const note = await create(user, {
+			preview: ps.preview,
+			createdAt: new Date(),
+			files: files,
+			poll: ps.poll ? {
+				choices: ps.poll.choices,
+				multiple: ps.poll.multiple || false,
+				expiresAt: ps.poll.expiresAt ? new Date(ps.poll.expiresAt) : null
+			} : undefined,
+			text: ps.text,
+			reply,
+			renote,
+			cw: ps.cw,
+			app,
+			viaMobile: ps.viaMobile,
+			localOnly: ps.localOnly,
+			copyOnce: ps.copyOnce,
+			visibility: ps.visibility,
+			visibleUsers,
+			apMentions: ps.noExtractMentions ? [] : undefined,
+			apHashtags: ps.noExtractHashtags ? [] : undefined,
+			apEmojis: ps.noExtractEmojis ? [] : undefined,
+			geo: ps.geo
+		});
 
-	return {
-		createdNote: await pack(note, user)
-	};
+		return {
+			createdNote: await pack(note, user)
+		};
+	} catch (err: unknown) {
+		if (err instanceof NoteError) {
+			if (err.type === 'cannotReRenote') throw new ApiError(meta.errors.cannotReRenote);
+			if (err.type === 'cannotReplyToPureRenote') throw new ApiError(meta.errors.cannotReplyToPureRenote);
+			throw new ApiError({ ...meta.errors.noteError, ...{ message: err.message } });
+		}
+		throw err;
+	}
 });

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -319,11 +319,6 @@ export default define(meta, async (ps, user, app) => {
 		}
 	}
 
-	// テキストが無いかつ添付ファイルが無いかつRenoteも無いかつ投票も無かったらエラー
-	if (!(ps.text || files.length || renote || ps.poll)) {
-		throw new ApiError(meta.errors.contentRequired);
-	}
-
 	// 後方互換性のため
 	if (ps.visibility == 'private') {
 		ps.visibility = 'specified';
@@ -363,6 +358,7 @@ export default define(meta, async (ps, user, app) => {
 		if (err instanceof NoteError) {
 			if (err.type === 'cannotReRenote') throw new ApiError(meta.errors.cannotReRenote);
 			if (err.type === 'cannotReplyToPureRenote') throw new ApiError(meta.errors.cannotReplyToPureRenote);
+			if (err.type === 'contentRequired') throw new ApiError(meta.errors.contentRequired);
 			throw new ApiError({ ...meta.errors.noteError, ...{ message: err.message } });
 		}
 		throw err;

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -299,7 +299,7 @@ export default define(meta, async (ps, user, app) => {
 		}
 
 		// 返信対象が引用でないRenoteだったらエラー
-		if (reply.replyId && !reply.text && reply.fileIds.length === 0) {
+		if (reply.renoteId && !reply.text && reply.fileIds.length === 0) {
 			throw new ApiError(meta.errors.cannotReplyToPureRenote);
 		}
 	}

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -273,20 +273,27 @@ export default define(meta, async (ps, user, app) => {
 		files = removeNull(_files);
 	}
 
+	const isPureRenote = (target: INote) => {
+		return target.renoteId && target.text == null && (target.fileIds == null || target.fileIds.length == 0) && target.poll == null;
+	};
+
+	// Renote/引用
 	let renote: INote | null | undefined = null;
 	if (ps.renoteId != null) {
-		// Fetch renote to note
 		renote = await Note.findOne({
 			_id: ps.renoteId
 		});
 
 		if (renote == null) {
 			throw new ApiError(meta.errors.noSuchRenoteTarget);
-		} else if (renote.renoteId && !renote.text && renote.fileIds.length === 0) {
+		}
+
+		if (isPureRenote(renote)) {
 			throw new ApiError(meta.errors.cannotReRenote);
 		}
 	}
 
+	// 返信
 	let reply: INote | null | undefined = null;
 	if (ps.replyId != null) {
 		// Fetch reply
@@ -299,7 +306,7 @@ export default define(meta, async (ps, user, app) => {
 		}
 
 		// 返信対象が引用でないRenoteだったらエラー
-		if (reply.renoteId && !reply.text && reply.fileIds.length === 0) {
+		if (isPureRenote(reply)) {
 			throw new ApiError(meta.errors.cannotReplyToPureRenote);
 		}
 	}

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -274,7 +274,7 @@ export default define(meta, async (ps, user, app) => {
 	}
 
 	const isPureRenote = (target: INote) => {
-		return target.renoteId && target.text == null && (target.fileIds == null || target.fileIds.length == 0) && target.poll == null;
+		return target.renoteId && target.text == null && (target.fileIds == null || target.fileIds.length === 0) && target.poll == null;
 	};
 
 	// Renote/引用

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -141,9 +141,9 @@ export default async (user: IUser, data: Option, silent = false) => {
 	if (config.disablePosts) throw { status: 451 };
 
 	const isFirstNote = user.notesCount === 0;
-	const thisIsPureRenote = data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length == 0);
+	const isPureRenote = data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length == 0);
 
-	const isPureRenote = (target: INote) => {
+	const targetIsPureRenote = (target: INote) => {
 		return target.renoteId && target.text == null && (target.fileIds == null || target.fileIds.length === 0) && target.poll == null;
 	};
 
@@ -189,12 +189,12 @@ export default async (user: IUser, data: Option, silent = false) => {
 	}
 
 	// PureRenoteはRenote/引用できない
-	if (data.renote && isPureRenote(data.renote)) {
+	if (data.renote && targetIsPureRenote(data.renote)) {
 		throw new NoteError('You can not Renote a pure Renote.', 'cannotReRenote');
 	}
 
 	// PureRenoteには返信できない
-	if (data.reply && isPureRenote(data.reply)) {
+	if (data.reply && targetIsPureRenote(data.reply)) {
 		throw new NoteError('You can not reply to a pure Renote.', 'cannotReplyToPureRenote');
 	}
 
@@ -209,7 +209,7 @@ export default async (user: IUser, data: Option, silent = false) => {
 	}
 
 	// PureRenoteの最大公開範囲はHomeにする
-	if (thisIsPureRenote && data.visibility === 'public') {
+	if (isPureRenote && data.visibility === 'public') {
 		data.visibility = 'home';
 	}
 

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -195,12 +195,12 @@ export default async (user: IUser, data: Option, silent = false) => {
 
 	// PureRenoteはRenote/引用できない
 	if (data.renote && targetIsPureRenote(data.renote)) {
-		throw new NoteError('You can not Renote a pure Renote.', 'cannotReRenote');
+		throw new NoteError('You can not Renote a pure Renote', 'cannotReRenote');
 	}
 
 	// PureRenoteには返信できない
 	if (data.reply && targetIsPureRenote(data.reply)) {
-		throw new NoteError('You can not reply to a pure Renote.', 'cannotReplyToPureRenote');
+		throw new NoteError('You can not reply to a pure Renote', 'cannotReplyToPureRenote');
 	}
 
 	// PureRenoteの最大公開範囲はHomeにする

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -160,32 +160,32 @@ export default async (user: IUser, data: Option, silent = false) => {
 	// 本文/CW/投票のハードリミット
 	// サロゲートペアは2文字扱い/合字は複数文字扱いでかける
 	if (data.text && data.text.length > 16384) {
-		throw 'text limit exceeded';
+		throw new NoteError('text limit exceeded');
 	}
 	if (data.cw && data.cw.length > 16384) {
-		throw 'cw limit exceeded';
+		throw new NoteError('cw limit exceeded');
 	}
 	if (data.poll && JSON.stringify(data.poll).length > 16384) {
-		throw 'poll limit exceeded';
+		throw new NoteError('poll limit exceeded');
 	}
 
 	if (data.copyOnce && data.visibility === 'specified') {
-		throw 'Deny remote follower only';
+		throw new NoteError('Deny remote follower only');
 	}
 
 	// リプライ対象が削除された投稿だったらreject
 	if (data.reply && data.reply.deletedAt != null) {
-		throw 'Reply target has been deleted';
+		throw new NoteError('Reply target has been deleted');
 	}
 
 	// Renote/Quote対象が削除された投稿だったらreject
 	if (data.renote && data.renote.deletedAt != null) {
-		throw 'Renote target has been deleted';
+		throw new NoteError('Renote target has been deleted');
 	}
 
 	// Renote/Quote対象が「ホームまたは全体」以外の公開範囲ならreject
 	if (data.renote && data.renote.visibility != 'public' && data.renote.visibility != 'home') {
-		throw 'Renote target is not public or home';
+		throw new NoteError('Renote target is not public or home');
 	}
 
 	// Renote/Quote対象がホームだったらホームに

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -141,9 +141,9 @@ export default async (user: IUser, data: Option, silent = false) => {
 	if (config.disablePosts) throw { status: 451 };
 
 	const isFirstNote = user.notesCount === 0;
-	const isPureRenote = data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length == 0);
+	const thisIsPureRenote = data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length == 0);
 
-	const targetIsPureRenote = (target: INote) => {
+	const isPureRenote = (target: INote) => {
 		return target.renoteId && target.text == null && (target.fileIds == null || target.fileIds.length === 0) && target.poll == null;
 	};
 
@@ -194,17 +194,17 @@ export default async (user: IUser, data: Option, silent = false) => {
 	}
 
 	// PureRenoteはRenote/引用できない
-	if (data.renote && targetIsPureRenote(data.renote)) {
+	if (data.renote && isPureRenote(data.renote)) {
 		throw new NoteError('You can not Renote a pure Renote', 'cannotReRenote');
 	}
 
 	// PureRenoteには返信できない
-	if (data.reply && targetIsPureRenote(data.reply)) {
+	if (data.reply && isPureRenote(data.reply)) {
 		throw new NoteError('You can not reply to a pure Renote', 'cannotReplyToPureRenote');
 	}
 
 	// PureRenoteの最大公開範囲はHomeにする
-	if (isPureRenote && data.visibility === 'public') {
+	if (thisIsPureRenote && data.visibility === 'public') {
 		data.visibility = 'home';
 	}
 

--- a/test/api.ts
+++ b/test/api.ts
@@ -39,45 +39,49 @@ describe('API', () => {
 	const aliceAction = (params: Record<string, any>) => api('notes/create', params, alice);
 
 	describe('Posts', () => {
-		// 普通の投稿
-		it('Can post', async(async () => {
+		it('Allow 通常投稿', async(async () => {
 			const res = await aliceAction({ text: 'post' });
 			alicePost1 = res.body.createdNote;
 			assert.strictEqual(alicePost1.text, 'post');
 		}));
 
-		it('Can upload', async(async () => {
+		it('Allow アップロード', async(async () => {
 			aliceFile1 = await uploadFile(alice);
 			assert.strictEqual(!!aliceFile1.id, true);
 		}));
 
-		// textない系投稿
-		it('Can fileonly post', async(async () => {
+		// 本文なし投稿
+		it('Deny 本文なし投稿', async(async () => {
+			const res = await aliceAction({});
+			assert.strictEqual(res.body.error.code, 'CONTENT_REQUIRED');
+		}));
+
+		it('Allow 本文なし投稿 - ファイルのみ', async(async () => {
 			const res = await aliceAction({ fileIds: [aliceFile1.id] });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.fileIds[0], aliceFile1.id);
 		}));
 
-		it('Deny 0 files post', async(async () => {
+		it('Deny 本文なし投稿 - ファイルのみ - 0', async(async () => {
 			const res = await aliceAction({ fileIds: [] });
 			assert.strictEqual(res.body.error.info.param, 'fileIds');
 		}));
 
-		it('Can pollonly post', async(async () => {
+		it('Allow 本文なし投稿 - 投票のみ', async(async () => {
 			const res = await aliceAction({ poll: { choices: ['a', 'b'] } });
 			const obj  = res.body.createdNote;
 			assert.strictEqual(!!obj.poll, true);
 		}));
 
 		// Renote
-		it('Can renote post', async(async () => {
+		it('Allow Renote', async(async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id });
 			aliceRenote1 = res.body.createdNote;
 			assert.strictEqual(aliceRenote1.renoteId, alicePost1.id);
 		}));
 
 		// 引用
-		it('Can quote post', async(async () => {
+		it('Allow 引用', async(async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id, text: 'quote' });
 			aliceQuote1 = res.body.createdNote;
 			assert.strictEqual(aliceQuote1.renoteId, alicePost1.id);
@@ -85,24 +89,24 @@ describe('API', () => {
 		}));
 
 		// Renote x Renote/引用
-		it('Deny renote renote', async(async () => {
+		it('Deny RenoteをRenote', async(async () => {
 			const res = await aliceAction({ renoteId: aliceRenote1.id });
 			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
 		}));
 
-		it('Can renote quote', async(async () => {
+		it('Allow 引用をRenote', async(async () => {
 			const res = await aliceAction({ renoteId: aliceQuote1.id });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceQuote1.id);
 		}));
 
 		// 引用 x Renote/引用
-		it('Deny quote renote', async(async () => {
+		it('Deny Renoteを引用', async(async () => {
 			const res = await aliceAction({ renoteId: aliceRenote1.id, text: 'x' });
 			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
 		}));
 
-		it('Can quote quote', async(async () => {
+		it('Allow 引用を引用', async(async () => {
 			const res = await aliceAction({ renoteId: aliceQuote1.id, text: 're-quote' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceQuote1.id);
@@ -110,7 +114,7 @@ describe('API', () => {
 		}));
 
 		// 返信
-		it('Can reply post', async(async () => {
+		it('Allow 返信', async(async () => {
 			const res = await aliceAction({ replyId: alicePost1.id, text: 'reply' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, alicePost1.id);
@@ -118,57 +122,59 @@ describe('API', () => {
 		}));
 
 		// 返信 x Renote/引用
-		it('Deny reply renote', async(async () => {
+		it('Deny Renoteに返信', async(async () => {
 			const res = await aliceAction({ replyId: aliceRenote1.id, text: 'x' });
 			assert.strictEqual(res.body.error.code, 'CANNOT_REPLY_TO_A_PURE_RENOTE');
 		}));
 
-		it('Can reply quote', async(async () => {
+		it('Allow 引用に返信', async(async () => {
 			const res = await aliceAction({ replyId: aliceQuote1.id, text: 'reply quote' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, aliceQuote1.id);
 			assert.strictEqual(obj.text, 'reply quote');
 		}));
 
-		// textない系引用
-		it('Can fileonly quote', async(async () => {
+		// 本文なし系引用
+		it('Allow 引用 - ファイルのみ', async(async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id, fileIds: [aliceFile1.id] });
 			aliceFileOnlyQuote1 = res.body.createdNote;
 			assert.strictEqual(aliceFileOnlyQuote1.renoteId, alicePost1.id);
 			assert.strictEqual(aliceFileOnlyQuote1.fileIds[0], aliceFile1.id);
 		}));
 
-		it('Can pollonly quote', async(async () => {
+		it('Allow 引用 - 投票のみ', async(async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id, poll: { choices: ['a', 'b'] } });
 			alicePollOnlyQuote1 = res.body.createdNote;
 			assert.strictEqual(alicePollOnlyQuote1.renoteId, alicePost1.id);
 			assert.strictEqual(!!alicePollOnlyQuote1.poll, true);
 		}));
 
-		// textない系引用をRenote
-		it('Can renote fileonly quote', async(async () => {
+		// 本文なし系引用をRenote
+		it('Allow ファイルのみ引用をRenote', async(async () => {
 			const res = await aliceAction({ renoteId: aliceFileOnlyQuote1.id });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceFileOnlyQuote1.id);
 		}));
 
-		it('Can renote pollonly quote', async(async () => {
+		it('Allow 投票のみ引用をRenote', async(async () => {
 			const res = await aliceAction({ renoteId: alicePollOnlyQuote1.id });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, alicePollOnlyQuote1.id);
 		}));
 
-		// textない系引用に返信
-		it('Can reply fileonly quote', async(async () => {
-			const res = await aliceAction({ replyId: aliceFileOnlyQuote1.id });
+		// 本文なし系引用に返信
+		it('Allow ファイルのみ引用に返信', async(async () => {
+			const res = await aliceAction({ replyId: aliceFileOnlyQuote1.id, text: 'rfoq' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, aliceFileOnlyQuote1.id);
+			assert.strictEqual(obj.text, 'rfoq');
 		}));
 
-		it('Can reply pollonly quote', async(async () => {
-			const res = await aliceAction({ replyId: alicePollOnlyQuote1.id });
+		it('Allow 投票のみ引用に返信', async(async () => {
+			const res = await aliceAction({ replyId: alicePollOnlyQuote1.id, text: 'rpoq' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, alicePollOnlyQuote1.id);
+			assert.strictEqual(obj.text, 'rpoq');
 		}));
 	});
 });

--- a/test/api.ts
+++ b/test/api.ts
@@ -17,8 +17,8 @@ describe('API', () => {
 	let aliceRenote1: PackedNote;
 	let aliceQuote1: PackedNote;
 	let aliceFile1: any;
-	let aliceFileOnlyQuote: PackedNote;
-	let alicePollOnlyQuote: PackedNote;
+	let aliceFileOnlyQuote1: PackedNote;
+	let alicePollOnlyQuote1: PackedNote;
 
 	before(async () => {
 		p = await startServer();
@@ -36,13 +36,12 @@ describe('API', () => {
 		await shutdownServer(p);
 	});
 
+	const aliceAction = (params: Record<string, any>) => api('notes/create', params, alice);
+
 	describe('Posts', () => {
 		// 普通の投稿
 		it('Can post', async(async () => {
-			const res = await api('notes/create',
-				{ text: 'post' },
-				alice
-			);
+			const res = await aliceAction({ text: 'post' });
 			alicePost1 = res.body.createdNote;
 			assert.strictEqual(alicePost1.text, 'post');
 		}));
@@ -54,117 +53,122 @@ describe('API', () => {
 
 		// textない系投稿
 		it('Can fileonly post', async(async () => {
-			const res = await api('notes/create',
-				{ fileIds: [aliceFile1.id] },
-				alice
-			);
+			const res = await aliceAction({ fileIds: [aliceFile1.id] });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.fileIds[0], aliceFile1.id);
 		}));
 
 		it('Deny 0 files post', async(async () => {
-			const res = await api('notes/create',
-				{ fileIds: [] },
-				alice
-			);
+			const res = await aliceAction({ fileIds: [] });
 			assert.strictEqual(res.body.error.info.param, 'fileIds');
 		}));
 
 		it('Can pollonly post', async(async () => {
-			const res = await api('notes/create',
-				{ poll: { choices: ['a', 'b'] } },
-				alice
-			);
+			const res = await aliceAction({ poll: { choices: ['a', 'b'] } });
 			const obj  = res.body.createdNote;
 			assert.strictEqual(!!obj.poll, true);
 		}));
 
 		// Renote
 		it('Can renote post', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: alicePost1.id },
-				alice
-			);
+			const res = await aliceAction({ renoteId: alicePost1.id });
 			aliceRenote1 = res.body.createdNote;
 			assert.strictEqual(aliceRenote1.renoteId, alicePost1.id);
 		}));
 
-		it('Deny renote renote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: aliceRenote1.id },
-				alice
-			);
-			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
-		}));
-
 		// 引用
 		it('Can quote post', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: alicePost1.id, text: 'quote' },
-				alice
-			);
+			const res = await aliceAction({ renoteId: alicePost1.id, text: 'quote' });
 			aliceQuote1 = res.body.createdNote;
 			assert.strictEqual(aliceQuote1.renoteId, alicePost1.id);
 			assert.strictEqual(aliceQuote1.text, 'quote');
 		}));
 
+		// Renote x Renote/引用
+		it('Deny renote renote', async(async () => {
+			const res = await aliceAction({ renoteId: aliceRenote1.id });
+			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
+		}));
+
+		it('Can renote quote', async(async () => {
+			const res = await aliceAction({ renoteId: aliceQuote1.id });
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.renoteId, aliceQuote1.id);
+		}));
+
+		// 引用 x Renote/引用
 		it('Deny quote renote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: aliceRenote1.id, text: 'x' },
-				alice
-			);
+			const res = await aliceAction({ renoteId: aliceRenote1.id, text: 'x' });
 			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
 		}));
 
 		it('Can quote quote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: aliceQuote1.id, text: 're-quote' },
-				alice
-			);
+			const res = await aliceAction({ renoteId: aliceQuote1.id, text: 're-quote' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceQuote1.id);
 			assert.strictEqual(obj.text, 're-quote');
 		}));
 
+		// 返信
+		it('Can reply post', async(async () => {
+			const res = await aliceAction({ replyId: alicePost1.id, text: 'reply' });
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.replyId, alicePost1.id);
+			assert.strictEqual(obj.text, 'reply');
+		}));
+
+		// 返信 x Renote/引用
+		it('Deny reply renote', async(async () => {
+			const res = await aliceAction({ replyId: aliceRenote1.id, text: 'x' });
+			assert.strictEqual(res.body.error.code, 'CANNOT_REPLY_TO_A_PURE_RENOTE');
+		}));
+
+		it('Can reply quote', async(async () => {
+			const res = await aliceAction({ replyId: aliceQuote1.id, text: 'reply quote' });
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.replyId, aliceQuote1.id);
+			assert.strictEqual(obj.text, 'reply quote');
+		}));
+
 		// textない系引用
 		it('Can fileonly quote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: alicePost1.id, fileIds: [aliceFile1.id] },
-				alice
-			);
-			aliceFileOnlyQuote = res.body.createdNote;
-			assert.strictEqual(aliceFileOnlyQuote.renoteId, alicePost1.id);
-			assert.strictEqual(aliceFileOnlyQuote.fileIds[0], aliceFile1.id);
+			const res = await aliceAction({ renoteId: alicePost1.id, fileIds: [aliceFile1.id] });
+			aliceFileOnlyQuote1 = res.body.createdNote;
+			assert.strictEqual(aliceFileOnlyQuote1.renoteId, alicePost1.id);
+			assert.strictEqual(aliceFileOnlyQuote1.fileIds[0], aliceFile1.id);
 		}));
 
 		it('Can pollonly quote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: alicePost1.id, poll: { choices: ['a', 'b'] } },
-				alice
-			);
-			alicePollOnlyQuote = res.body.createdNote;
-			assert.strictEqual(alicePollOnlyQuote.renoteId, alicePost1.id);
-			assert.strictEqual(!!alicePollOnlyQuote.poll, true);
+			const res = await aliceAction({ renoteId: alicePost1.id, poll: { choices: ['a', 'b'] } });
+			alicePollOnlyQuote1 = res.body.createdNote;
+			assert.strictEqual(alicePollOnlyQuote1.renoteId, alicePost1.id);
+			assert.strictEqual(!!alicePollOnlyQuote1.poll, true);
 		}));
 
-		it('Can quote fileonly quote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: aliceFileOnlyQuote.id, text: 'x' },
-				alice
-			);
+		// textない系引用をRenote
+		it('Can renote fileonly quote', async(async () => {
+			const res = await aliceAction({ renoteId: aliceFileOnlyQuote1.id });
 			const obj = res.body.createdNote;
-			assert.strictEqual(obj.renoteId, aliceFileOnlyQuote.id);
+			assert.strictEqual(obj.renoteId, aliceFileOnlyQuote1.id);
 		}));
 
-		it('Can quote pollonly quote', async(async () => {
-			const res = await api('notes/create',
-				{ renoteId: alicePollOnlyQuote.id, text: 'x' },
-				alice
-			);
+		it('Can renote pollonly quote', async(async () => {
+			const res = await aliceAction({ renoteId: alicePollOnlyQuote1.id });
 			const obj = res.body.createdNote;
-			assert.strictEqual(obj.renoteId, alicePollOnlyQuote.id);
+			assert.strictEqual(obj.renoteId, alicePollOnlyQuote1.id);
 		}));
 
-		// reply
+		// textない系引用に返信
+		it('Can reply fileonly quote', async(async () => {
+			const res = await aliceAction({ replyId: aliceFileOnlyQuote1.id });
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.replyId, aliceFileOnlyQuote1.id);
+		}));
+
+		it('Can reply pollonly quote', async(async () => {
+			const res = await aliceAction({ replyId: alicePollOnlyQuote1.id });
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.replyId, alicePollOnlyQuote1.id);
+		}));
 	});
 });

--- a/test/api.ts
+++ b/test/api.ts
@@ -4,7 +4,6 @@ import * as assert from 'assert';
 import * as childProcess from 'child_process';
 import { async, startServer, signup, api, shutdownServer, uploadFile } from './utils';
 import { PackedNote, PackedUser } from '../src/models/packed-schemas';
-import { inspect } from 'util';
 import { setTimeout } from 'timers/promises';
 
 const db = require('../built/db/mongodb').default;

--- a/test/api.ts
+++ b/test/api.ts
@@ -2,7 +2,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, startServer, signup, api, shutdownServer, uploadFile } from './utils';
+import { startServer, signup, api, shutdownServer, uploadFile } from './utils';
 import { PackedNote, PackedUser } from '../src/models/packed-schemas';
 import { setTimeout } from 'timers/promises';
 
@@ -38,142 +38,142 @@ describe('API', () => {
 	const aliceAction = (params: Record<string, any>) => api('notes/create', params, alice);
 
 	describe('Posts', () => {
-		it('Allow 通常投稿', async(async () => {
+		it('Allow 通常投稿', async () => {
 			const res = await aliceAction({ text: 'post' });
 			alicePost1 = res.body.createdNote;
 			assert.strictEqual(alicePost1.text, 'post');
-		}));
+		});
 
-		it('Allow アップロード', async(async () => {
+		it('Allow アップロード', async () => {
 			aliceFile1 = await uploadFile(alice);
 			assert.strictEqual(!!aliceFile1.id, true);
-		}));
+		});
 
 		// 本文なし投稿
-		it('Deny 本文なし投稿', async(async () => {
+		it('Deny 本文なし投稿', async () => {
 			const res = await aliceAction({});
 			assert.strictEqual(res.body.error.code, 'CONTENT_REQUIRED');
-		}));
+		});
 
-		it('Allow 本文なし投稿 - ファイルのみ', async(async () => {
+		it('Allow 本文なし投稿 - ファイルのみ', async () => {
 			const res = await aliceAction({ fileIds: [aliceFile1.id] });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.fileIds[0], aliceFile1.id);
-		}));
+		});
 
-		it('Deny 本文なし投稿 - ファイルのみ - 0', async(async () => {
+		it('Deny 本文なし投稿 - ファイルのみ - 0', async () => {
 			const res = await aliceAction({ fileIds: [] });
 			assert.strictEqual(res.body.error.info.param, 'fileIds');
-		}));
+		});
 
-		it('Allow 本文なし投稿 - 投票のみ', async(async () => {
+		it('Allow 本文なし投稿 - 投票のみ', async () => {
 			const res = await aliceAction({ poll: { choices: ['a', 'b'] } });
 			const obj  = res.body.createdNote;
 			assert.strictEqual(!!obj.poll, true);
-		}));
+		});
 
 		// Renote
-		it('Allow Renote', async(async () => {
+		it('Allow Renote', async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id });
 			aliceRenote1 = res.body.createdNote;
 			assert.strictEqual(aliceRenote1.renoteId, alicePost1.id);
-		}));
+		});
 
 		// 引用
-		it('Allow 引用', async(async () => {
+		it('Allow 引用', async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id, text: 'quote' });
 			aliceQuote1 = res.body.createdNote;
 			assert.strictEqual(aliceQuote1.renoteId, alicePost1.id);
 			assert.strictEqual(aliceQuote1.text, 'quote');
-		}));
+		});
 
 		// Renote x Renote/引用
-		it('Deny RenoteをRenote', async(async () => {
+		it('Deny RenoteをRenote', async () => {
 			const res = await aliceAction({ renoteId: aliceRenote1.id });
 			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
-		}));
+		});
 
-		it('Allow 引用をRenote', async(async () => {
+		it('Allow 引用をRenote', async () => {
 			const res = await aliceAction({ renoteId: aliceQuote1.id });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceQuote1.id);
-		}));
+		});
 
 		// 引用 x Renote/引用
-		it('Deny Renoteを引用', async(async () => {
+		it('Deny Renoteを引用', async () => {
 			const res = await aliceAction({ renoteId: aliceRenote1.id, text: 'x' });
 			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
-		}));
+		});
 
-		it('Allow 引用を引用', async(async () => {
+		it('Allow 引用を引用', async () => {
 			const res = await aliceAction({ renoteId: aliceQuote1.id, text: 're-quote' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceQuote1.id);
 			assert.strictEqual(obj.text, 're-quote');
-		}));
+		});
 
 		// 返信
-		it('Allow 返信', async(async () => {
+		it('Allow 返信', async () => {
 			const res = await aliceAction({ replyId: alicePost1.id, text: 'reply' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, alicePost1.id);
 			assert.strictEqual(obj.text, 'reply');
-		}));
+		});
 
 		// 返信 x Renote/引用
-		it('Deny Renoteに返信', async(async () => {
+		it('Deny Renoteに返信', async () => {
 			const res = await aliceAction({ replyId: aliceRenote1.id, text: 'x' });
 			assert.strictEqual(res.body.error.code, 'CANNOT_REPLY_TO_A_PURE_RENOTE');
-		}));
+		});
 
-		it('Allow 引用に返信', async(async () => {
+		it('Allow 引用に返信', async () => {
 			const res = await aliceAction({ replyId: aliceQuote1.id, text: 'reply quote' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, aliceQuote1.id);
 			assert.strictEqual(obj.text, 'reply quote');
-		}));
+		});
 
 		// 本文なし系引用
-		it('Allow 引用 - ファイルのみ', async(async () => {
+		it('Allow 引用 - ファイルのみ', async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id, fileIds: [aliceFile1.id] });
 			aliceFileOnlyQuote1 = res.body.createdNote;
 			assert.strictEqual(aliceFileOnlyQuote1.renoteId, alicePost1.id);
 			assert.strictEqual(aliceFileOnlyQuote1.fileIds[0], aliceFile1.id);
-		}));
+		});
 
-		it('Allow 引用 - 投票のみ', async(async () => {
+		it('Allow 引用 - 投票のみ', async () => {
 			const res = await aliceAction({ renoteId: alicePost1.id, poll: { choices: ['a', 'b'] } });
 			alicePollOnlyQuote1 = res.body.createdNote;
 			assert.strictEqual(alicePollOnlyQuote1.renoteId, alicePost1.id);
 			assert.strictEqual(!!alicePollOnlyQuote1.poll, true);
-		}));
+		});
 
 		// 本文なし系引用をRenote
-		it('Allow ファイルのみ引用をRenote', async(async () => {
+		it('Allow ファイルのみ引用をRenote', async () => {
 			const res = await aliceAction({ renoteId: aliceFileOnlyQuote1.id });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, aliceFileOnlyQuote1.id);
-		}));
+		});
 
-		it('Allow 投票のみ引用をRenote', async(async () => {
+		it('Allow 投票のみ引用をRenote', async () => {
 			const res = await aliceAction({ renoteId: alicePollOnlyQuote1.id });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.renoteId, alicePollOnlyQuote1.id);
-		}));
+		});
 
 		// 本文なし系引用に返信
-		it('Allow ファイルのみ引用に返信', async(async () => {
+		it('Allow ファイルのみ引用に返信', async () => {
 			const res = await aliceAction({ replyId: aliceFileOnlyQuote1.id, text: 'rfoq' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, aliceFileOnlyQuote1.id);
 			assert.strictEqual(obj.text, 'rfoq');
-		}));
+		});
 
-		it('Allow 投票のみ引用に返信', async(async () => {
+		it('Allow 投票のみ引用に返信', async () => {
 			const res = await aliceAction({ replyId: alicePollOnlyQuote1.id, text: 'rpoq' });
 			const obj = res.body.createdNote;
 			assert.strictEqual(obj.replyId, alicePollOnlyQuote1.id);
 			assert.strictEqual(obj.text, 'rpoq');
-		}));
+		});
 	});
 });

--- a/test/api.ts
+++ b/test/api.ts
@@ -2,8 +2,10 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, startServer, signup, api, shutdownServer } from './utils';
+import { async, startServer, signup, api, shutdownServer, uploadFile } from './utils';
 import { PackedNote, PackedUser } from '../src/models/packed-schemas';
+import { inspect } from 'util';
+import { setTimeout } from 'timers/promises';
 
 const db = require('../built/db/mongodb').default;
 
@@ -13,14 +15,18 @@ describe('API', () => {
 	let alice: PackedUser;
 	let alicePost1: PackedNote;
 	let aliceRenote1: PackedNote;
+	let aliceQuote1: PackedNote;
+	let aliceFile1: any;
+	let aliceFileOnlyQuote: PackedNote;
+	let alicePollOnlyQuote: PackedNote;
 
 	before(async () => {
 		p = await startServer();
+		await setTimeout(1000);
 		await Promise.all([
 			db.get('users').drop(),
 			db.get('notes').drop(),
 		]);
-
 		// signup
 		alice = await signup({ username: 'alice' });
 		//console.log('alice', alice);
@@ -31,16 +37,50 @@ describe('API', () => {
 	});
 
 	describe('Posts', () => {
+		// 普通の投稿
 		it('Can post', async(async () => {
 			const res = await api('notes/create',
-				{ text: 'post1' },
+				{ text: 'post' },
 				alice
 			);
 			alicePost1 = res.body.createdNote;
-			assert.strictEqual(alicePost1.text, 'post1');
+			assert.strictEqual(alicePost1.text, 'post');
 		}));
 
-		it('Can renote', async(async () => {
+		it('Can upload', async(async () => {
+			aliceFile1 = await uploadFile(alice);
+			assert.strictEqual(!!aliceFile1.id, true);
+		}));
+
+		// textない系投稿
+		it('Can fileonly post', async(async () => {
+			const res = await api('notes/create',
+				{ fileIds: [aliceFile1.id] },
+				alice
+			);
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.fileIds[0], aliceFile1.id);
+		}));
+
+		it('Deny 0 files post', async(async () => {
+			const res = await api('notes/create',
+				{ fileIds: [] },
+				alice
+			);
+			assert.strictEqual(res.body.error.info.param, 'fileIds');
+		}));
+
+		it('Can pollonly post', async(async () => {
+			const res = await api('notes/create',
+				{ poll: { choices: ['a', 'b'] } },
+				alice
+			);
+			const obj  = res.body.createdNote;
+			assert.strictEqual(!!obj.poll, true);
+		}));
+
+		// Renote
+		it('Can renote post', async(async () => {
 			const res = await api('notes/create',
 				{ renoteId: alicePost1.id },
 				alice
@@ -49,13 +89,82 @@ describe('API', () => {
 			assert.strictEqual(aliceRenote1.renoteId, alicePost1.id);
 		}));
 
-		it('Cant re-renote', async(async () => {
+		it('Deny renote renote', async(async () => {
 			const res = await api('notes/create',
 				{ renoteId: aliceRenote1.id },
 				alice
 			);
-
 			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
 		}));
+
+		// 引用
+		it('Can quote post', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: alicePost1.id, text: 'quote' },
+				alice
+			);
+			aliceQuote1 = res.body.createdNote;
+			assert.strictEqual(aliceQuote1.renoteId, alicePost1.id);
+			assert.strictEqual(aliceQuote1.text, 'quote');
+		}));
+
+		it('Deny quote renote', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: aliceRenote1.id, text: 'x' },
+				alice
+			);
+			assert.strictEqual(res.body.error.code, 'CANNOT_RENOTE_TO_A_PURE_RENOTE');
+		}));
+
+		it('Can quote quote', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: aliceQuote1.id, text: 're-quote' },
+				alice
+			);
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.renoteId, aliceQuote1.id);
+			assert.strictEqual(obj.text, 're-quote');
+		}));
+
+		// textない系引用
+		it('Can fileonly quote', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: alicePost1.id, fileIds: [aliceFile1.id] },
+				alice
+			);
+			aliceFileOnlyQuote = res.body.createdNote;
+			assert.strictEqual(aliceFileOnlyQuote.renoteId, alicePost1.id);
+			assert.strictEqual(aliceFileOnlyQuote.fileIds[0], aliceFile1.id);
+		}));
+
+		it('Can pollonly quote', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: alicePost1.id, poll: { choices: ['a', 'b'] } },
+				alice
+			);
+			alicePollOnlyQuote = res.body.createdNote;
+			assert.strictEqual(alicePollOnlyQuote.renoteId, alicePost1.id);
+			assert.strictEqual(!!alicePollOnlyQuote.poll, true);
+		}));
+
+		it('Can quote fileonly quote', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: aliceFileOnlyQuote.id, text: 'x' },
+				alice
+			);
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.renoteId, aliceFileOnlyQuote.id);
+		}));
+
+		it('Can quote pollonly quote', async(async () => {
+			const res = await api('notes/create',
+				{ renoteId: alicePollOnlyQuote.id, text: 'x' },
+				alice
+			);
+			const obj = res.body.createdNote;
+			assert.strictEqual(obj.renoteId, alicePollOnlyQuote.id);
+		}));
+
+		// reply
 	});
 });


### PR DESCRIPTION
## Summary
Fix #4736

RenoteのReplyを修正
投票のみ引用投稿をRenote出来ないのを修正
投票のみ引用投稿に返信出来ないのを修正
APからの投稿に、空投稿制約とRe-Renote制約が効くように
APIで投稿での諸々の制約違反で500ではなく400 with NoteErrorを返すように
テストを追加

制約はendpointではなくserviceに書くように