### PR TITLE
HTTP Signature検証のリファクタ

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -57,23 +57,9 @@ async function inbox(ctx: Router.RouterContext) {
 	let signature: httpSignature.IParsedSignature;
 
 	try {
-		signature = httpSignature.parseRequest(ctx.req, { 'headers': [] });
+		signature = httpSignature.parseRequest(ctx.req, { 'headers': ['(request-target)', 'digest', 'host', 'date'] });
 	} catch (e) {
 		logger.warn(`inbox: signature parse error: ${inspect(e)}`);
-		ctx.status = 401;
-		return;
-	}
-
-	// 署名必須ヘッダーの検証
-	if (!['host', 'digest'].every(h => signature.params.headers.includes(h))) {
-		logger.warn(`inbox: missing required header`);
-		ctx.status = 401;
-		return;
-	}
-
-	// Hostヘッダーの検証
-	if (ctx.headers.host !== config.host) {
-		logger.warn(`inbox: host headr missmatch`);
 		ctx.status = 401;
 		return;
 	}


### PR DESCRIPTION
## Summary
https://github.com/mei23/misskey/pull/4749 を少しシンプルにする、効力は変わらない。

署名必須ヘッダーの検証はライブラリの機能にあるのでそれを使用するようにする。
もちろん、DigestヘッダーがBodyのそれと一致するかみたいな照合は別途必要なのでそのまま。

bodyParser使用はわかりずらいのでそのまま。

## 仕様の変更

署名対象ヘッダーに (request-target), date が含まれない実装からのActivityも弾かれるようになる可能性があるが、実影響はないと思われる。

dateが300秒以上ずれている場合 (主にどちらかの時計が狂っている場合) 弾かれるようになります。


https://git.joinfirefish.org/firefish/firefish/-/commit/3272b908c63b24f056d01c180e546f124009a6d1
```
Co-authored-by: Laura Hausmann <laura@hausmann.dev>
```
