### PR TITLE
Tune AP HTML

### DIFF
--- a/src/mfm/to-html.ts
+++ b/src/mfm/to-html.ts
@@ -34,6 +34,10 @@ export function toHtml(nodes: MfmNode[] | null, mentionedRemoteUsers: INote['men
 		*/
 
 		if (node.type === 'text') {
+			if (!node.props.text.match(/[\r\n]/)) {
+				return doc.createTextNode(node.props.text);
+			}
+
 			const el = doc.createElement('span');
 			const nodes = (node.props.text as string).split(/\r\n|\r|\n/).map(x => doc.createTextNode(x) as Node);
 

--- a/src/remote/activitypub/misc/get-note-html.ts
+++ b/src/remote/activitypub/misc/get-note-html.ts
@@ -2,9 +2,21 @@ import { INote } from '../../../models/note';
 import { toHtml } from '../../../mfm/to-html';
 import { parseFull } from '../../../mfm/parse';
 
-export function getNoteHtml(note: INote) {
-	let html = toHtml(parseFull(note.text), note.mentionedRemoteUsers);
+export function getNoteHtml(note: INote, apAppend?: string) {
+	let noMisskeyContent = false;
+	const srcMfm = (note.text ?? '') + (apAppend ?? '');
+
+	const nodes = parseFull(srcMfm);
+
+	if (!apAppend && nodes?.every(node => ['text', 'emoji', 'mention', 'hashtag', 'url'].includes(node.type))) {
+		noMisskeyContent = true;
+	}
+
+	let html = toHtml(nodes, note.mentionedRemoteUsers);
 	if (html == null) html = '<p>.</p>';
 
-	return html;
+	return {
+		content: html,
+		noMisskeyContent,
+	};
 }

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -93,18 +93,15 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 
 	const text = note.text;
 
-	let apText = text;
-	if (apText == null) apText = '';
+	let apAppend = '';
 
 	if (quote) {
-		apText += `\n\nRE: ${quote}`;
+		apAppend += `\n\nRE: ${quote}`;
 	}
 
 	const summary = note.cw === '' ? String.fromCharCode(0x200B) : note.cw;
 
-	const content = getNoteHtml(Object.assign({}, note, {
-		text: apText
-	}));
+	const { content, noMisskeyContent } = getNoteHtml(note, apAppend);
 
 	const emojis = await getEmojis(note.emojis);
 	const apemojis = emojis.map(emoji => renderEmoji(emoji));
@@ -123,9 +120,6 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 
 	const asPoll = note.poll ? {
 		type: 'Question',
-		content: getNoteHtml(Object.assign({}, note, {
-			text: text
-		})),
 		[expiresAt && expiresAt < new Date() ? 'closed' : 'endTime']: expiresAt,
 		[multiple ? 'anyOf' : 'oneOf']: choices.map(({ text, votes }) => ({
 			type: 'Note',
@@ -144,7 +138,7 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		attributedTo,
 		summary,
 		content,
-		_misskey_content: text,
+		...(noMisskeyContent ? {} : { _misskey_content: text }),
 		_misskey_quote: quote,
 		quoteUri: quote,
 		published: note.createdAt.toISOString(),

--- a/src/server/web/feed/json.ts
+++ b/src/server/web/feed/json.ts
@@ -169,7 +169,7 @@ export async function getJSONFeed(acct: string, untilId?: string) {
 			id: noteUrl,
 			url: noteUrl,
 			title: `New post by ${name}`,
-			content_html: note.text != null ? getNoteHtml(note, '').content : undefined,
+			content_html: note.text != null ? getNoteHtml(note).content : undefined,
 			content_text: note.text != null ? note.text : undefined,
 			summary: note.cw != null ? note.cw : undefined,
 			image: image ? getDriveFileUrl(image) : undefined,

--- a/src/server/web/feed/json.ts
+++ b/src/server/web/feed/json.ts
@@ -169,7 +169,7 @@ export async function getJSONFeed(acct: string, untilId?: string) {
 			id: noteUrl,
 			url: noteUrl,
 			title: `New post by ${name}`,
-			content_html: note.text != null ? getNoteHtml(note) : undefined,
+			content_html: note.text != null ? getNoteHtml(note, '').content : undefined,
 			content_text: note.text != null ? note.text : undefined,
 			summary: note.cw != null ? note.cw : undefined,
 			image: image ? getDriveFileUrl(image) : undefined,

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -1435,15 +1435,15 @@ describe('toHtml', () => {
 	});
 
 	it('blod', () => {
-		assert.equal(toHtml(parseFull('a**b**c')!), `<p><span>a</span><b><span>b</span></b><span>c</span></p>`);
+		assert.equal(toHtml(parseFull('a**b**c')!), `<p>a<b>b</b>c</p>`);
 	});
 
 	it('small', () => {
-		assert.equal(toHtml(parseFull('a<small>b</small>c')!), `<p><span>a</span><small><span>b</span></small><span>c</span></p>`);
+		assert.equal(toHtml(parseFull('a<small>b</small>c')!), `<p>a<small>b</small>c</p>`);
 	});
 
 	it('italic', () => {
-		assert.equal(toHtml(parseFull('a<i>b</i>c')!), `<p><span>a</span><i><span>b</span></i><span>c</span></p>`);
+		assert.equal(toHtml(parseFull('a<i>b</i>c')!), `<p>a<i>b</i>c</p>`);
 	});
 
 	/*
@@ -1457,15 +1457,15 @@ describe('toHtml', () => {
 	*/
 
 	it('strike', () => {
-		assert.equal(toHtml(parseFull('a~~b~~c')!), `<p><span>a</span><del><span>b</span></del><span>c</span></p>`);
+		assert.equal(toHtml(parseFull('a~~b~~c')!), `<p>a<del>b</del>c</p>`);
 	});
 
 	it('quote', () => {
-		assert.equal(toHtml(parseFull('a\n> b\nc')!), `<p><span>a<br></span><blockquote><span>b</span></blockquote><span>c</span></p>`);
+		assert.equal(toHtml(parseFull('a\n> b\nc')!), `<p><span>a<br></span><blockquote>b</blockquote>c</p>`);
 	});
 
 	it('inlineCode', () => {
-		assert.equal(toHtml(parseFull('a`b`c')!), `<p><span>a</span><code>b</code><span>c</span></p>`);
+		assert.equal(toHtml(parseFull('a`b`c')!), `<p>a<code>b</code>c</p>`);
 	});
 
 	it('blockCode', () => {
@@ -1477,7 +1477,7 @@ describe('toHtml', () => {
 	});
 
 	it('title', () => {
-		assert.equal(toHtml(parseFull('【a】')!), `<p><h1><span>a</span></h1></p>`);
+		assert.equal(toHtml(parseFull('【a】')!), `<p><h1>a</h1></p>`);
 	});
 
 	it('ruby', () => {


### PR DESCRIPTION
## Summary
Resolve #4747
Resolve #4757

AP HTMLにて無駄なspanを除去
AP HTMLで安全に復元可能なら_misskey_contentを使わないように
