### PR TITLE
Deliver queueのJSONシリアライズとダイジェスト計算は事前に行うように

### DIFF
--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -15,6 +15,7 @@ import { IMute } from '../models/mute';
 import { IActivity } from '../remote/activitypub/type';
 import queueChart from '../services/chart/queue';
 import { cpus } from 'os';
+import { createDigest } from '../remote/activitypub/ap-request';
 
 const deliverLogger = queueLogger.createSubLogger('deliver');
 const webpushDeliverLogger = queueLogger.createSubLogger('webpushDeliver');
@@ -119,12 +120,15 @@ export function deliver(user: ILocalUser, content: any, to: string, lowSeverity 
 
 	if (content == null) return null;
 
+	const contentBody = JSON.stringify(content);
+
 	const data = {
 		user: {
 			_id: `${user._id}`,
 			keypair: user.keypair
 		},
-		content,
+		content: contentBody,
+		digest: createDigest(contentBody),
 		to,
 		inboxInfo
 	};

--- a/src/queue/processors/deliver.ts
+++ b/src/queue/processors/deliver.ts
@@ -106,8 +106,10 @@ type DeliverContent = {
 	};
 };
 
-export function publicToHome(content: DeliverContent, user: ThinUser): DeliverContent {
-	if (content.type === 'Create' && content.object.type === 'Note') {
+export function publicToHome(org: DeliverContent, user: ThinUser): DeliverContent {
+	if (org.type === 'Create' && org.object.type === 'Note') {
+		const content: DeliverContent = JSON.parse(JSON.stringify(org));
+
 		const asPublic = 'https://www.w3.org/ns/activitystreams#Public';
 		const followers = `${config.url}/users/${user._id}/followers`;
 
@@ -127,6 +129,6 @@ export function publicToHome(content: DeliverContent, user: ThinUser): DeliverCo
 
 		return content;
 	} else {
-		return content;
+		return org;
 	}
 }

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -16,7 +16,7 @@ export type DeliverJobData = {
 	user: ThinUserWithKey;
 	/** Activity */
 	content: string;
-	/** DigestHeader */
+	/** Digest header */
 	digest: string;
 	/** inbox URL to deliver */
 	to: string;

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -15,7 +15,9 @@ export type DeliverJobData = {
 	/** Actor */
 	user: ThinUserWithKey;
 	/** Activity */
-	content: any;
+	content: string;
+	/** DigestHeader */
+	digest: string;
 	/** inbox URL to deliver */
 	to: string;
 	/** Detail information of inbox */

--- a/src/remote/activitypub/ap-request.ts
+++ b/src/remote/activitypub/ap-request.ts
@@ -16,9 +16,9 @@ type PrivateKey = {
 	keyId: string;
 };
 
-export function createSignedPost(args: { key: PrivateKey, url: string, body: string, additionalHeaders: Record<string, string> }) {
+export function createSignedPost(args: { key: PrivateKey, url: string, body: string, digest?: string, additionalHeaders: Record<string, string> }) {
 	const u = new URL(args.url);
-	const digestHeader = `SHA-256=${crypto.createHash('sha256').update(args.body).digest('base64')}`;
+	const digestHeader = args.digest ?? createDigest(args.body);
 
 	const request: Request = {
 		url: u.href,
@@ -39,6 +39,10 @@ export function createSignedPost(args: { key: PrivateKey, url: string, body: str
 		signature: result.signature,
 		signatureHeader: result.signatureHeader,
 	};
+}
+
+export function createDigest(body: string) {
+	return `SHA-256=${crypto.createHash('sha256').update(body).digest('base64')}`;
 }
 
 export function createSignedGet(args: { key: PrivateKey, url: string, additionalHeaders: Record<string, string> }) {

--- a/src/remote/activitypub/deliver-manager.ts
+++ b/src/remote/activitypub/deliver-manager.ts
@@ -135,7 +135,7 @@ export default class DeliverManager {
 				if (await isClosedHost(host)) continue;
 
 				if (await isSelfSilencedHost(host)) {
-					const act = publicToHome(JSON.parse(JSON.stringify(this.activity)), this.actor); 
+					const act = publicToHome(this.activity, this.actor); 
 					deliver(this.actor, act, inbox.url, lowSeverity, inbox);
 				} else {
 					deliver(this.actor, this.activity, inbox.url, lowSeverity, inbox);

--- a/src/remote/activitypub/deliver-manager.ts
+++ b/src/remote/activitypub/deliver-manager.ts
@@ -2,7 +2,8 @@ import { isRemoteUser, IRemoteUser, isLocalUser, ILocalUser } from '../../models
 import Following from '../../models/following';
 import { deliver } from '../../queue';
 import { InboxInfo } from '../../queue/types';
-import { isBlockedHost, isClosedHost } from '../../services/instance-moderation';
+import { isBlockedHost, isClosedHost, isSelfSilencedHost } from '../../services/instance-moderation';
+import { publicToHome } from '../../queue/processors/deliver';
 
 //#region types
 interface IRecipe {
@@ -132,7 +133,14 @@ export default class DeliverManager {
 				const { host } = new URL(inbox.url);
 				if (await isBlockedHost(host)) continue;
 				if (await isClosedHost(host)) continue;
-				deliver(this.actor, this.activity, inbox.url, lowSeverity, inbox);
+
+				if (await isSelfSilencedHost(host)) {
+					const act = publicToHome(JSON.parse(JSON.stringify(this.activity)), this.actor); 
+					deliver(this.actor, act, inbox.url, lowSeverity, inbox);
+				} else {
+					deliver(this.actor, this.activity, inbox.url, lowSeverity, inbox);
+				}
+
 			} catch { }
 		}
 	}

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -4,8 +4,8 @@ import { createSignedPost, createSignedGet } from './ap-request';
 import { ILocalUser } from '../../models/user';
 import { ThinUserWithKey } from '../../queue/types';
 
-export default async (user: ThinUserWithKey, url: string, object: any) => {
-	const body = JSON.stringify(object);
+export default async (user: ThinUserWithKey, url: string, object: any, digest?: string) => {
+	const body = typeof object === 'string' ? object : JSON.stringify(object);
 
 	const req = createSignedPost({
 		key: {
@@ -14,6 +14,7 @@ export default async (user: ThinUserWithKey, url: string, object: any) => {
 		},
 		url,
 		body,
+		digest,
 		additionalHeaders: {
 			'User-Agent': config.userAgent,
 		}


### PR DESCRIPTION
## Summary
Deliver queueのJSONシリアライズとダイジェスト計算は事前に行うように
```
アクティビティ
↓JSONシリアライズ x 配信先の数
Redis
↓(JSONデシリアライズ + JSONシリアライズ + ダイジェスト計算) x 配信先の数 x リトライの度


アクティビティ
↓(JSONシリアライズ + ダイジェスト計算) x 1回
Redis
↓なし
```
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
