### PR TITLE
ステータスコードハンドリング等の修正

### DIFF
--- a/src/misc/fetch.ts
+++ b/src/misc/fetch.ts
@@ -189,12 +189,20 @@ export class StatusError extends Error {
 	public statusCode: number;
 	public statusMessage?: string;
 	public isClientError: boolean;
+	public isPermanentError: boolean;
 
 	constructor(message: string, statusCode: number, statusMessage?: string) {
 		super(message);
 		this.name = 'StatusError';
 		this.statusCode = statusCode;
 		this.statusMessage = statusMessage;
-		this.isClientError = typeof this.statusCode === 'number' && this.statusCode >= 400 && this.statusCode < 500;
+
+		this.isClientError = false;
+		this.isPermanentError = false;
+
+		if (typeof this.statusCode === 'number' && this.statusCode >= 400 && this.statusCode < 500) {
+			this.isClientError = true;
+			this.isPermanentError = this.statusCode !== 408 && this.statusCode !== 429;
+		}
 	}
 }

--- a/src/queue/processors/deliver.ts
+++ b/src/queue/processors/deliver.ts
@@ -65,9 +65,9 @@ export default async (job: Bull.Job<DeliverJobData>) => {
 
 		if (res instanceof StatusError) {
 			// 4xx
-			if (res.isClientError) {
+			if (res.isPermanentError) {
 				// Mastodonから返ってくる401がどうもpermanent errorじゃなさそう
-				if (res.statusCode === 401 || res.statusCode === 408 || res.statusCode === 429) {
+				if (res.statusCode === 401) {
 					throw `${res.statusCode} ${res.statusMessage}`;
 				}
 

--- a/src/queue/processors/inbox.ts
+++ b/src/queue/processors/inbox.ts
@@ -66,8 +66,7 @@ export const tryProcessInbox = async (data: InboxJobData, ctx?: ApContext): Prom
 		try {
 			user = await resolvePerson(getApId(activity.actor), undefined, resolver, isDelete(activity) || isUndo(activity)) as IRemoteUser;
 		} catch (e) {
-			// 対象が4xxならスキップ
-			if (e instanceof StatusError && e.isClientError) {
+			if (e instanceof StatusError && e.isPermanentError) {
 				return `skip: Ignored actor ${activity.actor} - ${e.statusCode}`;
 			}
 			throw `Error in actor ${activity.actor} - ${e.statusCode || e}`;

--- a/src/remote/activitypub/kernel/create/index.ts
+++ b/src/remote/activitypub/kernel/create/index.ts
@@ -4,6 +4,7 @@ import createNote from './note';
 import { ICreate, getApId, isPost, getApType } from '../../type';
 import { apLogger } from '../../logger';
 import { toArray, concat, unique } from '../../../../prelude/array';
+import { StatusError } from '../../../../misc/fetch';
 
 const logger = apLogger;
 
@@ -36,6 +37,9 @@ export default async (actor: IRemoteUser, activity: ICreate): Promise<string> =>
 		object = await resolver.resolve(activity.object);
 	} catch (e) {
 		logger.error(`Resolution failed: ${e}`);
+		if (e instanceof StatusError && e.isPermanentError) {
+			return `${e.statusCode} ${e.statusMessage}`;
+		}
 		throw e;
 	}
 

--- a/src/remote/activitypub/kernel/create/note.ts
+++ b/src/remote/activitypub/kernel/create/note.ts
@@ -33,7 +33,7 @@ export default async function(resolver: Resolver, actor: IRemoteUser, note: IObj
 		const n = await createNote(note, resolver, silent);
 		return n ? 'ok' : 'skip';
 	} catch (e) {
-		if (e instanceof StatusError && e.isClientError) {
+		if (e instanceof StatusError && e.isPermanentError) {
 			return `skip ${e.statusCode}`;
 		} else {
 			throw e;

--- a/src/remote/activitypub/models/image.ts
+++ b/src/remote/activitypub/models/image.ts
@@ -36,7 +36,7 @@ export async function createImage(actor: IRemoteUser, value: IObject): Promise<I
 		file = await uploadFromUrl({ url: image.url, user: actor, uri: image.url, sensitive: !!image.sensitive, isLink: !cache });
 	} catch (e) {
 		// 4xxの場合は添付されてなかったことにする
-		if (e instanceof StatusError && e.isClientError) {
+		if (e instanceof StatusError && e.isPermanentError) {
 			logger.warn(`Ignored image: ${image.url} - ${e.statusCode}`);
 			return null;
 		}


### PR DESCRIPTION
## Summary
全体的にHTTPリクエストの永続的エラー判定で、4xxでも408と429は除外するように。
InboxでNode.objectが永続的エラーでもリトライしてしまうのを修正。 (Bearcapsなど)