### PR TITLE
Fix: メール配送が無効ならばメールを送ることのないように

### DIFF
--- a/src/services/send-email.ts
+++ b/src/services/send-email.ts
@@ -8,6 +8,8 @@ export const logger = new Logger('email');
 export async function sendEmail(to: string, subject: string, text: string) {
 	const meta = await fetchMeta();
 
+	if (!meta.enableEmail) return;
+
 	const enableAuth = meta.smtpUser != null && meta.smtpUser !== '';
 
 	const transporter = nodemailer.createTransport({


### PR DESCRIPTION
Do not send email if email delivery is disabled

メール配送の有効化スイッチがただの飾りになってしまってる

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
