### PR TITLE
Tune: hideServerInfo applies to streaming

### DIFF
--- a/src/server/api/stream/channels/server-stats.ts
+++ b/src/server/api/stream/channels/server-stats.ts
@@ -1,6 +1,7 @@
 import autobind from 'autobind-decorator';
 import Xev from 'xev';
 import Channel from '../channel';
+import config from '../../../../config';
 
 const ev = new Xev();
 
@@ -15,11 +16,13 @@ export default class extends Channel {
 
 	@autobind
 	private onStats(stats: any) {
+		if (config.hideServerInfo) return;
 		this.send('stats', stats);
 	}
 
 	@autobind
 	public onMessage(type: string, body: any) {
+		if (config.hideServerInfo) return;
 		switch (type) {
 			case 'requestLog':
 				ev.once(`serverStatsLog:${body.id}`, statsLog => {


### PR DESCRIPTION
## Summary

Server-stats is seems to be unavailable if config.hideServerInfo is set.
However in some cases, we can still receive server-stats using streaming connection.
We can't receive server-stats via server-info endpoint. 