### PR TITLE
ドライブファイルのstaleキャッシュ制御

### DIFF
--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -184,7 +184,7 @@ async function sendNormal(ctx: Router.RouterContext, body: Buffer | stream.Strea
 			return;
 		}
 	} else {
-		ctx.set('Cache-Control', 'max-age=2592000, s-maxage=172800, immutable');
+		ctx.set('Cache-Control', 'max-age=2592000, s-maxage=172800, stale-while-revalidate=300, stale-if-error=86400, immutable');
 	}
 
 	ctx.body = body;

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -297,7 +297,7 @@ async function upload(key: string, stream: fs.ReadStream | Buffer, type: string,
 		Key: key,
 		Body: stream,
 		ContentType: type,
-		CacheControl: 'max-age=2592000, s-maxage=172800, immutable',
+		CacheControl: 'max-age=2592000, s-maxage=172800, stale-while-revalidate=300, stale-if-error=86400 immutable',
 	} as PutObjectCommandInput;
 
 	if (filename) params.ContentDisposition = contentDisposition('inline', filename);

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -297,7 +297,7 @@ async function upload(key: string, stream: fs.ReadStream | Buffer, type: string,
 		Key: key,
 		Body: stream,
 		ContentType: type,
-		CacheControl: 'max-age=2592000, s-maxage=172800, stale-while-revalidate=300, stale-if-error=86400 immutable',
+		CacheControl: 'max-age=2592000, s-maxage=172800, stale-while-revalidate=300, stale-if-error=86400, immutable',
 	} as PutObjectCommandInput;
 
 	if (filename) params.ContentDisposition = contentDisposition('inline', filename);


### PR DESCRIPTION
## Summary
Resolve #4828

時折不安定な動作を示すシステム向けのキャッシュ制御を更新しました

ドライブファイルのHTTPキャッシュ制御を更新

- max-age: レスポンスがクライアントのキャッシュに保存される期間を示します。ここでは、2592000秒（30日間）に設定されました。
- s-maxage: レスポンスが共有キャッシュ（プロキシなど）に保存される期間を示します。ここでは、172800秒（2日間）に設定されました。
- stale-while-revalidate: クライアントが古いキャッシュを使用してリクエストを行い、同時にバックエンドサーバーに新しいリソースを要求する期間を示します。ここでは、300秒（5分間）に設定されました。
- stale-if-error: バックエンドサーバーがエラーを返した場合に、クライアントがキャッシュを使用することができる期間を示します。ここでは、86400秒（1日間）に設定されました。

これにより、ドライブファイルにアクセスする際のキャッシュの動作が最適化され、ウェブサービスのパフォーマンスと可用性が向上します。

文章はAI生成