### PR TITLE
Only allow exact id matches

### DIFF
--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -80,7 +80,10 @@ export async function apGet(url: string, user?: ILocalUser) {
 
 	if (res.body.length > 65536) throw new Error('too large JSON');
 
-	return await JSON.parse(res.body);
+	return {
+		object: await JSON.parse(res.body),
+		res,
+	};
 }
 
 function validateContentType(contentType: string | null | undefined): boolean {

--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -66,20 +66,39 @@ export default class Resolver {
 			this.user = await getInstanceActor();
 		}
 
-		const object = await apGet(value, this.user);
+		const { object, res } = await apGet(value, this.user);
 
 		if (object === null || (
 			Array.isArray(object['@context']) ?
 				!object['@context'].includes('https://www.w3.org/ns/activitystreams') :
 				object['@context'] !== 'https://www.w3.org/ns/activitystreams'
 		)) {
-			throw {
-				name: `InvalidResponse`,
-				statusCode: 482,
-				message: `Invalid @context`
-			};
+			throw new StatusError(`Invalid @context`, 482);
 		}
 
-		return object;
+		// reject no object id
+		if (object.id == null) {
+			throw new StatusError(`Object has no ID`, 482);
+		}
+
+		// final landing url === responsed object id => success
+		if (res.url === object.id) {
+			return object;
+		}
+
+		// reject final landing host !== responsed object id host
+		if (new URL(res.url).host !== new URL(object.id).host) {
+			throw new StatusError(`Object ID host doesn't match final url host`, 482);
+		}
+
+		// second attempt by first id
+		const second = await apGet(object.id, this.user);
+
+		// final landing url === responsed object id => success
+		if (second.res.url !== second.object.id) {
+			throw new StatusError(`Object ID still doesn't match final URL after second fetch attempt`, 482);
+		}
+
+		return second.object;
 	}
 }


### PR DESCRIPTION
## Summary
Strict AP object id check
The id property of the retrieved object must match the final redirect URL actually attempted.

https://akkoma.dev/AkkomaGang/akkoma/commit/8684964c5d03f6c70f73730b3f1ad26784ffb004
https://firefish.dev/firefish/firefish/-/merge_requests/10718/commits

多分、[ドライブファイル等にAP Objectっぽいのを上げられた時にfakeオブジェクトが出来てしまう場合](https://github.com/misskey-dev/misskey/security/advisories/GHSA-qqrm-9grj-6v32)とかの受け側の対策。
現状のContent-Typeチェックである程度大丈夫な気はするけど、このチェックによってドライブファイル等アップロード後のURLが予測困難な場合攻撃が困難になるから多層防御として有効？