### PR TITLE
ap document

### DIFF
--- a/src/models/drive-file.ts
+++ b/src/models/drive-file.ts
@@ -14,6 +14,7 @@ DriveFile.createIndex('metadata.uri');
 DriveFile.createIndex('metadata.userId');
 DriveFile.createIndex('metadata.folderId');
 DriveFile.createIndex('metadata._user.host');
+DriveFile.createIndex('metadata.apId', { sparse: true, unique: true });
 export default DriveFile;
 
 export const DriveFileChunk = db.get('driveFiles.chunks');
@@ -47,6 +48,9 @@ export type IMetadata = {
 	_user: any;
 	folderId: mongo.ObjectID;
 	comment: string;
+
+	/** ActivityPub object ID */
+	apId?: string;
 
 	/**
 	 * リモートインスタンスから取得した場合の元URL

--- a/src/remote/activitypub/kernel/update/index.ts
+++ b/src/remote/activitypub/kernel/update/index.ts
@@ -1,10 +1,11 @@
 import { IRemoteUser } from '../../../../models/user';
-import { IUpdate, isActor, getApType, isPost } from '../../type';
+import { IUpdate, isActor, getApType, isPost, isDocument } from '../../type';
 import { apLogger } from '../../logger';
 import { updateQuestion } from '../../models/question';
 import Resolver from '../../resolver';
 import { updatePerson } from '../../models/person';
 import updateNote from './note';
+import { updateImage } from '../../models/image';
 
 /**
  * Updateアクティビティを捌きます
@@ -31,6 +32,8 @@ export default async (actor: IRemoteUser, activity: IUpdate): Promise<string> =>
 		return `ok: Question updated`;
 	} else if (isPost(object)) {
 		return await updateNote(actor, object);
+	} else if (isDocument(object)) {
+		return await updateImage(actor, object);
 	} else {
 		return `skip: Unknown type: ${getApType(object)}`;
 	}

--- a/src/remote/activitypub/renderer/document.ts
+++ b/src/remote/activitypub/renderer/document.ts
@@ -1,7 +1,9 @@
 import { IDriveFile } from '../../../models/drive-file';
 import getDriveFileUrl from '../../../misc/get-drive-file-url';
+import config from '../../../config';
 
 export default (file: IDriveFile) => ({
+	id: `${config.url}/activitypub/documents/${file._id}`,
 	type: 'Document',
 	mediaType: file.contentType,
 	sensitive: !!file.metadata?.isSensitive,

--- a/src/remote/activitypub/renderer/image.ts
+++ b/src/remote/activitypub/renderer/image.ts
@@ -1,8 +1,11 @@
 import { IDriveFile } from '../../../models/drive-file';
 import getDriveFileUrl from '../../../misc/get-drive-file-url';
+import config from '../../../config';
 
 export default (file: IDriveFile) => ({
+	id: `${config.url}/activitypub/documents/${file._id}`,
 	type: 'Image',
-	url: getDriveFileUrl(file),
-	sensitive: !!file.metadata?.isSensitive
+	mediaType: file.contentType,
+	sensitive: !!file.metadata?.isSensitive,
+	url: getDriveFileUrl(file)
 });

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -388,7 +388,7 @@ type AddFileArgs = {
 	uri?: string | null;
 	/** CommMark file as sensitiveent */
 	sensitive?: boolean;
-	apId?: string | null;
+	apId?: string;
 }
 
 /**
@@ -406,7 +406,7 @@ export async function addFile({
 	url = null,
 	uri = null,
 	sensitive = false,
-	apId = null,
+	apId = undefined,
 }: AddFileArgs): Promise<IDriveFile> {
 	const info = await getFileInfo(path);
 	logger.info(`${JSON.stringify(info)}`);
@@ -515,8 +515,9 @@ export async function addFile({
 		withoutChunks: isLink,
 		isRemote: isLink,
 		isSensitive: (isLocalUser(user) && user.settings?.alwaysMarkNsfw) || sensitive,
-		apId,
 	} as IMetadata;
+
+	if (apId != null) metadata.apId = apId;
 
 	if (url !== null) {
 		metadata.src = url;
@@ -561,7 +562,7 @@ export async function addFile({
 		driveFile = await (save(path, detectedName, info, metadata, drive));
 	}
 
-	if (!driveFile) throw 'Failed to create drivefile ${e}';
+	if (!driveFile) throw `Failed to create drivefile`;
 
 	logger.succ(`drive file has been created ${driveFile._id}`);
 

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -388,6 +388,7 @@ type AddFileArgs = {
 	uri?: string | null;
 	/** CommMark file as sensitiveent */
 	sensitive?: boolean;
+	apId?: string | null;
 }
 
 /**
@@ -405,6 +406,7 @@ export async function addFile({
 	url = null,
 	uri = null,
 	sensitive = false,
+	apId = null,
 }: AddFileArgs): Promise<IDriveFile> {
 	const info = await getFileInfo(path);
 	logger.info(`${JSON.stringify(info)}`);
@@ -512,7 +514,8 @@ export async function addFile({
 		properties: properties,
 		withoutChunks: isLink,
 		isRemote: isLink,
-		isSensitive: (isLocalUser(user) && user.settings?.alwaysMarkNsfw) || sensitive
+		isSensitive: (isLocalUser(user) && user.settings?.alwaysMarkNsfw) || sensitive,
+		apId,
 	} as IMetadata;
 
 	if (url !== null) {

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -16,6 +16,7 @@ type Args = {
 	sensitive?: boolean;
 	force?: boolean;
 	isLink?: boolean;
+	apId?: string | null;
 }
 
 export async function uploadFromUrl({
@@ -25,7 +26,8 @@ export async function uploadFromUrl({
 	uri = null,
 	sensitive = false,
 	force = false,
-	isLink = false
+	isLink = false,
+	apId = null,
 }: Args): Promise<IDriveFile> {
 	// Create temp file
 	const [path, cleanup] = await createTemp();
@@ -41,11 +43,11 @@ export async function uploadFromUrl({
 		name = null;
 	}
 
-	let driveFile: IDriveFile;
+	let driveFile: IDriveFile | null = null;
 	let error;
 
 	try {
-		driveFile = await addFile({ user, path, name, folderId, force, isLink, url, uri, sensitive });
+		driveFile = await addFile({ user, path, name, folderId, force, isLink, url, uri, sensitive, apId });
 		logger.succ(`Got: ${driveFile._id}`);
 	} catch (e) {
 		error = e;
@@ -58,7 +60,7 @@ export async function uploadFromUrl({
 	// clean-up
 	cleanup();
 
-	if (error) {
+	if (error || !driveFile) {
 		throw error;
 	} else {
 		return driveFile;

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -16,7 +16,7 @@ type Args = {
 	sensitive?: boolean;
 	force?: boolean;
 	isLink?: boolean;
-	apId?: string | null;
+	apId?: string;
 }
 
 export async function uploadFromUrl({
@@ -27,7 +27,7 @@ export async function uploadFromUrl({
 	sensitive = false,
 	force = false,
 	isLink = false,
-	apId = null,
+	apId,
 }: Args): Promise<IDriveFile> {
 	// Create temp file
 	const [path, cleanup] = await createTemp();


### PR DESCRIPTION
## Summary
Misskeyの添付ファイルの実態は投稿とは独立して存在できるDriveFileである。
しかし、AP実装は投稿の付随としてしか存在できないオブジェクトとなっている。
そのため、不都合が生じている。
添付ファイルをMisskeyのスキーマのように独立して存在出来る (つまり重複検知と更新もできる) オブジェクトとして扱うこことにより、数々の問題が解決出来る。例えばsensitiveとかを投稿に依存せずに反映するとか。(Mastodonの投稿をUpdateはなんか違う感) あとPG Misskey 参照カウント0のリモートファイル消さないのも間接的にどうにかできる (本来の対応じゃないかも)。

- Note.attachement[Document] に idを追加
- それをDB DriveFileにapIdとして保存できるように
- 重複判定を実フェッチしてMD5を確認するアルゴリズムから提供されたIDで確認するように
- ドライブファイル自体を変更したときのUpdateの送出と受信
  - Mastodon対応とか言ならUpdate.Note送っとけばいいかも。ただのこれの受信はめんどくさい (特に合意形成が) からやりたくないわね。だから送るだけにする。
  - Updateはフルペイロードを送るのでsecurirty/privacyに注意 !localOnly ...
  - GETで参照できるEPはsecurirty/privacy的に保留

：

- [ ] PG版Misskeyでも実装して動作を見る

：